### PR TITLE
Compatibility fix for Python 3.5 and earlier

### DIFF
--- a/xword_dl.py
+++ b/xword_dl.py
@@ -64,7 +64,7 @@ class AmuseLabsDownloader(BaseDownloader):
 
         rawc = rawc.split("'")[1]
 
-        xword_data = json.loads(base64.b64decode(rawc))
+        xword_data = json.loads(base64.b64decode(rawc).decode("utf-8"))
 
         self.puzfile.title = xword_data.get('title', '')
         self.puzfile.author = xword_data.get('author', '')


### PR DESCRIPTION
Prior to Python 3.6, `json.loads` did not automatically decode Unicode-encoded bytes-like objects. This adds an explicit UTF-8 decode after the base64 decode, so that it will work in earlier versions of Python.