### PR TITLE
A little drive-by refactoring

### DIFF
--- a/xword_dl.py
+++ b/xword_dl.py
@@ -179,9 +179,6 @@ class AmuseLabsDownloader(BaseDownloader):
 
         return puzzle
 
-    def save_puz(self, puzzle):
-        super().save_puz(puzzle)
-
 
 class WaPoDownloader(AmuseLabsDownloader):
     def __init__(self, output=None, **kwargs):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -59,15 +59,17 @@ class BaseDownloader:
         filename_components = [component for component in
                                             [self.outlet_prefix, self.date,
                                              puzzle.title] if component]
-        self.output =  " - ".join(filename_components) + '.puz'
+        return " - ".join(filename_components) + '.puz'
 
     def save_puz(self, puzzle):
-        if not self.output:
-            self.pick_filename(puzzle)
+        if self.output:
+            filename = self.output
+        else:
+            filename = self.pick_filename(puzzle)
 
-        self.output = remove_invalid_chars_from_filename(self.output)
+        filename = remove_invalid_chars_from_filename(filename)
 
-        save_puzzle(puzzle, self.output)
+        save_puzzle(puzzle, filename)
 
 class AmuseLabsDownloader(BaseDownloader):
     def __init__(self, output=None, **kwargs):
@@ -271,7 +273,7 @@ class LATimesDownloader(AmuseLabsDownloader):
         filename_components = [component for component in
                                             [self.outlet_prefix, self.date,
                                              use_title] if component]
-        self.output =  " - ".join(filename_components) + '.puz'
+        return " - ".join(filename_components) + '.puz'
 
 
 class NewYorkerDownloader(AmuseLabsDownloader):
@@ -328,7 +330,7 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         self.find_puzzle_url_from_id()
 
     def pick_filename(self, puzzle):
-        self.output =  " - ".join([self.outlet_prefix, self.date]) + '.puz'
+        return " - ".join([self.outlet_prefix, self.date]) + '.puz'
 
 
 class WSJDownloader(BaseDownloader):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -31,7 +31,6 @@ class BaseDownloader:
         self.output = output
         if self.output and not self.output.endswith('.puz'):
             self.output = self.output + '.puz'
-        self.puzfile = puz.Puzzle()
 
         self.outlet_prefix = None
         self.date = None
@@ -98,6 +97,7 @@ class AmuseLabsDownloader(BaseDownloader):
 
         xword_data = json.loads(base64.b64decode(rawc).decode("utf-8"))
 
+        self.puzfile = puz.Puzzle()
         self.puzfile.title = xword_data.get('title', '')
         self.puzfile.author = xword_data.get('author', '')
         self.puzfile.copyright = xword_data.get('copyright', '')
@@ -375,6 +375,7 @@ class WSJDownloader(BaseDownloader):
         for field in ['title', 'byline', 'publisher']:
             fetched[field] = html2text(xword_metadata.get(field, ''), bodywidth=0).strip()
 
+        self.puzfile = puz.Puzzle()
         self.puzfile.title = fetched.get('title')
         self.puzfile.author = fetched.get('byline')
         self.puzfile.copyright = fetched.get('publisher')
@@ -450,6 +451,7 @@ class USATodayDownloader(BaseDownloader):
         else:
             print('Failed to download puzzle.')
 
+        self.puzfile = puz.Puzzle()
         self.puzfile.title = xword_data.get('Title', '')
         self.puzfile.author = ''.join([xword_data.get('Author', ''),
                                        ' / Ed. ',

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -86,8 +86,8 @@ class AmuseLabsDownloader(BaseDownloader):
     def guess_date_from_id(self):
         self.date = self.id.split('_')[-1]
 
-    def download(self):
-        res = requests.get(self.url)
+    def download(self, url):
+        res = requests.get(url)
         rawc = next((line.strip() for line in res.text.splitlines()
                         if 'window.rawc' in line), None)
 
@@ -363,9 +363,9 @@ class WSJDownloader(BaseDownloader):
             puzzle_link = soup.find('iframe').get('src')
             self.find_solver(puzzle_link)
 
-    def download(self):
-        self.url = self.url.replace('index.html', 'data.json')
-        json_data = requests.get(self.url, headers=self.headers).json()['data']
+    def download(self, url):
+        json_url = url.replace('index.html', 'data.json')
+        json_data = requests.get(json_url, headers=self.headers).json()['data']
         xword_metadata = json_data.get('copy', '')
         xword_data = json_data.get('grid','')
 
@@ -436,11 +436,11 @@ class USATodayDownloader(BaseDownloader):
     def find_solver(self):
         pass
 
-    def download(self):
+    def download(self, url):
         attempts = 3
         while attempts:
             try:
-                res = requests.get(self.url)
+                res = requests.get(url)
                 xword_data = res.json()
                 break
             except json.JSONDecodeError:
@@ -604,7 +604,7 @@ def main():
     elif args.latest:
         dl.find_latest()
 
-    dl.download()
+    dl.download(dl.url)
     dl.save_puz()
 
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -48,15 +48,15 @@ class BaseDownloader:
 
         self.guess_url_from_date()
 
-    def pick_filename(self):
+    def pick_filename(self, puzzle):
         filename_components = [component for component in
                                             [self.outlet_prefix, self.date,
-                                             self.puzfile.title] if component]
+                                             puzzle.title] if component]
         self.output =  " - ".join(filename_components) + '.puz'
 
     def save_puz(self, puzzle):
         if not self.output:
-            self.pick_filename()
+            self.pick_filename(puzzle)
 
         invalid_chars = '<>:"/\|?*'
 
@@ -254,8 +254,8 @@ class LATimesDownloader(AmuseLabsDownloader):
     def find_solver(self, url):
         self.url = url
 
-    def pick_filename(self):
-        split_on_dashes = self.puzfile.title.split(' - ')
+    def pick_filename(self, puzzle):
+        split_on_dashes = puzzle.title.split(' - ')
         if len(split_on_dashes) > 1:
             use_title = split_on_dashes[-1].strip()
         else:
@@ -320,7 +320,7 @@ class NewYorkerDownloader(AmuseLabsDownloader):
 
         self.find_puzzle_url_from_id()
 
-    def pick_filename(self):
+    def pick_filename(self, puzzle):
         self.output =  " - ".join([self.outlet_prefix, self.date]) + '.puz'
 
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -19,6 +19,13 @@ from unidecode import unidecode
 
 __version__ = '2020.11.9'
 
+def save_puzzle(puzzle, filename):
+    if not os.path.exists(filename):
+        puzzle.save(filename)
+        print("Puzzle downloaded and saved as {}.".format(filename))
+    else:
+        print("Not saving: a file named {} already exists.".format(filename))
+
 class BaseDownloader:
     def __init__(self, output=None):
         self.output = output
@@ -56,12 +63,7 @@ class BaseDownloader:
         for char in invalid_chars:
             self.output = self.output.replace(char, '')
 
-        if not os.path.exists(self.output):
-            self.puzfile.save(self.output)
-            print("Puzzle downloaded and saved as {}.".format(self.output))
-        else:
-            print("Not saving: a file named {} already exists.".format(self.output))
-
+        save_puzzle(self.puzfile, self.output)
 
 class AmuseLabsDownloader(BaseDownloader):
     def __init__(self, output=None, **kwargs):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -56,6 +56,9 @@ class BaseDownloader:
         self.guess_url_from_date()
 
     def pick_filename(self, puzzle):
+        if not self.date:
+            self.guess_date_from_id()
+
         filename_components = [component for component in
                                             [self.outlet_prefix, self.date,
                                              puzzle.title] if component]
@@ -177,8 +180,6 @@ class AmuseLabsDownloader(BaseDownloader):
         return puzzle
 
     def save_puz(self, puzzle):
-        if not self.output and not self.date:
-            self.guess_date_from_id()
         super().save_puz(puzzle)
 
 
@@ -270,6 +271,9 @@ class LATimesDownloader(AmuseLabsDownloader):
         else:
             use_title = ''
 
+        if not self.date:
+            self.guess_date_from_id()
+
         filename_components = [component for component in
                                             [self.outlet_prefix, self.date,
                                              use_title] if component]
@@ -330,6 +334,9 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         self.find_puzzle_url_from_id()
 
     def pick_filename(self, puzzle):
+        if not self.date:
+            self.guess_date_from_id()
+
         return " - ".join([self.outlet_prefix, self.date]) + '.puz'
 
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -54,7 +54,7 @@ class BaseDownloader:
                                              self.puzfile.title] if component]
         self.output =  " - ".join(filename_components) + '.puz'
 
-    def save_puz(self):
+    def save_puz(self, puzzle):
         if not self.output:
             self.pick_filename()
 
@@ -63,7 +63,7 @@ class BaseDownloader:
         for char in invalid_chars:
             self.output = self.output.replace(char, '')
 
-        save_puzzle(self.puzfile, self.output)
+        save_puzzle(puzzle, self.output)
 
 class AmuseLabsDownloader(BaseDownloader):
     def __init__(self, output=None, **kwargs):
@@ -167,10 +167,10 @@ class AmuseLabsDownloader(BaseDownloader):
             self.puzfile._extensions_order.extend([b'GRBS', b'RTBL'])
             self.puzfile.rebus()
 
-    def save_puz(self):
+    def save_puz(self, puzzle):
         if not self.output and not self.date:
             self.guess_date_from_id()
-        super().save_puz()
+        super().save_puz(puzzle)
 
 
 class WaPoDownloader(AmuseLabsDownloader):
@@ -605,7 +605,7 @@ def main():
         dl.find_latest()
 
     dl.download(dl.url)
-    dl.save_puz()
+    dl.save_puz(dl.puzfile)
 
 
 if __name__ == '__main__':

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -64,16 +64,6 @@ class BaseDownloader:
                                              puzzle.title] if component]
         return " - ".join(filename_components) + '.puz'
 
-    def save_puz(self, puzzle):
-        if self.output:
-            filename = self.output
-        else:
-            filename = self.pick_filename(puzzle)
-
-        filename = remove_invalid_chars_from_filename(filename)
-
-        save_puzzle(puzzle, filename)
-
 class AmuseLabsDownloader(BaseDownloader):
     def __init__(self, output=None, **kwargs):
         super().__init__(output)
@@ -623,8 +613,15 @@ def main():
         dl.find_latest()
 
     puzzle = dl.download(dl.url)
-    dl.save_puz(puzzle)
 
+    if dl.output:
+        filename = dl.output
+    else:
+        filename = dl.pick_filename(puzzle)
+
+    filename = remove_invalid_chars_from_filename(filename)
+
+    save_puzzle(puzzle, filename)
 
 if __name__ == '__main__':
     main()

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -26,6 +26,14 @@ def save_puzzle(puzzle, filename):
     else:
         print("Not saving: a file named {} already exists.".format(filename))
 
+def remove_invalid_chars_from_filename(filename):
+    invalid_chars = '<>:"/\|?*'
+
+    for char in invalid_chars:
+        filename = filename.replace(char, '')
+
+    return filename
+
 class BaseDownloader:
     def __init__(self, output=None):
         self.output = output
@@ -57,10 +65,7 @@ class BaseDownloader:
         if not self.output:
             self.pick_filename(puzzle)
 
-        invalid_chars = '<>:"/\|?*'
-
-        for char in invalid_chars:
-            self.output = self.output.replace(char, '')
+        self.output = remove_invalid_chars_from_filename(self.output)
 
         save_puzzle(puzzle, self.output)
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -35,11 +35,7 @@ def remove_invalid_chars_from_filename(filename):
     return filename
 
 class BaseDownloader:
-    def __init__(self, output=None):
-        self.output = output
-        if self.output and not self.output.endswith('.puz'):
-            self.output = self.output + '.puz'
-
+    def __init__(self):
         self.outlet_prefix = None
         self.date = None
 
@@ -65,8 +61,8 @@ class BaseDownloader:
         return " - ".join(filename_components) + '.puz'
 
 class AmuseLabsDownloader(BaseDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output)
+    def __init__(self, **kwargs):
+        super().__init__()
 
     def find_latest(self):
         res = requests.get(self.picker_url)
@@ -171,8 +167,8 @@ class AmuseLabsDownloader(BaseDownloader):
 
 
 class WaPoDownloader(AmuseLabsDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.picker_url = 'https://cdn1.amuselabs.com/wapo/wp-picker?set=wapo-eb'
         self.url_from_id = 'https://cdn1.amuselabs.com/wapo/crossword?id={puzzle_id}&set=wapo-eb'
@@ -193,8 +189,8 @@ class WaPoDownloader(AmuseLabsDownloader):
 
 
 class AtlanticDownloader(AmuseLabsDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.picker_url = 'https://cdn3.amuselabs.com/atlantic/date-picker?set=atlantic'
         self.url_from_id = 'https://cdn3.amuselabs.com/atlantic/crossword?id={puzzle_id}&set=atlantic'
@@ -212,8 +208,8 @@ class AtlanticDownloader(AmuseLabsDownloader):
 
 
 class NewsdayDownloader(AmuseLabsDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.picker_url = 'https://cdn2.amuselabs.com/pmm/date-picker?set=creatorsweb'
         self.url_from_id = 'https://cdn2.amuselabs.com/pmm/crossword?id={puzzle_id}&set=creatorsweb'
@@ -231,8 +227,8 @@ class NewsdayDownloader(AmuseLabsDownloader):
 
 
 class LATimesDownloader(AmuseLabsDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.picker_url = 'https://cdn4.amuselabs.com/lat/date-picker?set=latimes'
         self.url_from_id = 'https://cdn4.amuselabs.com/lat/crossword?id={puzzle_id}&set=latimes'
@@ -268,8 +264,8 @@ class LATimesDownloader(AmuseLabsDownloader):
 
 
 class NewYorkerDownloader(AmuseLabsDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.url_from_id = 'https://cdn3.amuselabs.com/tny/crossword?id={puzzle_id}&set=tny-weekly'
 
@@ -328,8 +324,8 @@ class NewYorkerDownloader(AmuseLabsDownloader):
 
 
 class WSJDownloader(BaseDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
         self.outlet_prefix = 'WSJ'
         self.headers = {'User-Agent':'xword-dl'}
@@ -425,8 +421,8 @@ class WSJDownloader(BaseDownloader):
 
 
 class USATodayDownloader(BaseDownloader):
-    def __init__(self, output=None, **kwargs):
-        super().__init__(output)
+    def __init__(self, **kwargs):
+        super().__init__()
 
         self.outlet_prefix = 'USA Today'
 
@@ -600,7 +596,7 @@ def main():
     if not args.downloader_class:
         sys.exit(parser.print_help())
 
-    dl = args.downloader_class(output=args.output)
+    dl = args.downloader_class()
 
     if args.date:
         entered_date = ' '.join(args.date)
@@ -614,10 +610,10 @@ def main():
 
     puzzle = dl.download(dl.url)
 
-    if dl.output:
-        filename = dl.output
-    else:
-        filename = dl.pick_filename(puzzle)
+    filename = args.output or dl.pick_filename(puzzle)
+
+    if not filename.endswith('.puz'):
+        filename = filename + '.puz'
 
     filename = remove_invalid_chars_from_filename(filename)
 


### PR DESCRIPTION
These changes accomplish a few things:

* Make download() return a Puzzle.
* Remove dl.save_puz() and have a free function `save_puzzle(puzzle, filename)`.

Along the way we clean up the code path for picking a filename automatically if the user doesn't explicitly pass the `-o` argument.

A bad smell from the original code is that the downloader object is a big ball of mutable state with various concerns, which tries to share some code via inheritance.  However, in the inherited methods it is not always clear what part of the state should be already set or not.

May I suggest that you read the commits from oldest to newest; each individual commit tries to be a small refactoring operation that doesn't change the behavior of the code.

The changes are done with this mindset:

* Each downloader (which probably should be called PuzzleVenue or something) should be responsible only for figuring out the final URL from the latest, or from a given date, or by digging into a given URL with each venue's specific find_solver logic.
* Downloading should be generic?  I.e. you should be able to `while(some_retries): request.get(final_url)` and return the result, regardless of venue?
* Then, each PuzzleVenue should also be responsible for parsing the reply and generating a Puzzle.  This is mostly already achieved, except for the downloading-with-retries bit.
* Saving is generic; this is already achieved.

Some things I would try to fix:

* Similar to the series of commits, try to not have a `self.url` field.  Instead, have venue-specific methods to compute a final url and return it - given "latest", given a date, and given a URL that must be dug into like for NewYorker and WSJ.  (Why is `find_solver` in USAToday `pass`?  Is this an oversight?)

* The implementations of `pick_filename` are very similar.  They basically `join(outlet_prefix, date, title)` depending on what is available.  As an exception, `LATimesDownloader` munges the title beforehand.  As another exception, `NewYorkerDownloader` doesn't use the title at all.  I'm not sure if that is because its title is never suitable, or if you implemented it before you had the generic logic in `BaseDownloader.pick_filename`, which works even if any of the components is not set.  Maybe have a virtual method `make_suitable_title(self, puzzle)` which munges `puzzle.title` for `LATimesDownloader`, or which returns None for NewYorker.  Then you can have a single `pick_filename` in the base class, which depends on the `make_suitable_title` vmethod and that's all.

In the end, main() should look something like

```python
if args.latest:
    url = dl.find_latest()
elif args.date:
    date = parse_date_or_exit(args.date)
    url = dl.find_by_date(date)
elif args.spec_url:
    url = dl.find_solver(args.spec_url)     # maybe call it find_by_url()?
else:
    print_help_and_exit()

reply = download_with_retries(url)
puzzle = dl.parse_reply_into_puzzle(reply)

# ... saving code which is already in place
```