### PR TITLE
Add some unit tests and CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    main()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on: [push, pull_request]
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U pytest pytest-cov
+
+      - name: Install xword-dl
+        run: |
+          python -m pip install -e .
+
+      - name: Tests
+        run: |
+          python -m pytest --cov xword_dl --cov tests --cov-report xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.codecov-flag }}
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,20 @@
 *.puz
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Unit test / coverage reports
+*,cover
+.cache
+.coverage
+.coverage.*
+.testmondata
+coverage.xml
+htmlcov/

--- a/tests/test_amuselabs.py
+++ b/tests/test_amuselabs.py
@@ -1,0 +1,101 @@
+import datetime as dt
+
+import puz
+
+import xword_dl
+
+
+class TestWaPoDownloader:
+    def test_find_puzzle_url_from_id(self):
+        # Arrange
+        downloader = xword_dl.WaPoDownloader()
+        puzzle_id = "ebirnholz_201227"
+
+        # Act
+        url = downloader.find_puzzle_url_from_id(puzzle_id)
+
+        # Assert
+        assert (
+            url == "https://cdn1.amuselabs.com/wapo/crossword"
+            "?id=ebirnholz_201227&set=wapo-eb"
+        )
+
+    def test_parse_xword(self):
+        # Arrange
+        downloader = xword_dl.WaPoDownloader()
+        xword_data = {
+            "title": " my crossword ",
+            "box": [["B", "I", "G"], ["P", "I", "G"]],
+            "w": 2,
+            "h": 2,
+            "placedWords": [
+                {
+                    "word": "ROCK",
+                    "x": 0,
+                    "y": 0,
+                    "acrossNotDown": True,
+                    "clue": {"clue": " 'n' roll"},
+                }
+            ],
+        }
+
+        # Act
+        puzzle = downloader.parse_xword(xword_data)
+
+        # Assert
+        assert puzzle.title == "my crossword"
+        assert puzzle.width == 2
+        assert puzzle.height == 2
+
+    def test_pick_filename(self):
+        # Arrange
+        downloader = xword_dl.WaPoDownloader()
+        puzzle = puz.Puzzle()
+        puzzle.id = "ebirnholz_201227"
+
+        # Act
+        filename = downloader.pick_filename(puzzle)
+
+        # Assert
+        assert filename == "WaPo.puz"
+
+    def test_guess_date_from_id(self):
+        # Arrange
+        downloader = xword_dl.WaPoDownloader()
+        puzzle_id = "ebirnholz_201227"
+
+        # Act
+        downloader.guess_date_from_id(puzzle_id)
+
+        # Assert
+        assert downloader.date == dt.datetime(2020, 12, 27, 0, 0)
+
+    def test_find_by_date(self):
+        # Arrange
+        downloader = xword_dl.WaPoDownloader()
+        today = dt.datetime(2020, 12, 28, 19, 34, 14, 943230)
+
+        # Act
+        url = downloader.find_by_date(today)
+
+        # Assert
+        assert (
+            url == "https://cdn1.amuselabs.com/wapo/crossword"
+            "?id=ebirnholz_201228&set=wapo-eb"
+        )
+
+
+class TestAtlanticDownloader:
+    def test_find_by_date(self):
+        # Arrange
+        downloader = xword_dl.AtlanticDownloader()
+        today = dt.datetime(2020, 12, 28, 19, 34, 14, 943230)
+
+        # Act
+        url = downloader.find_by_date(today)
+
+        # Assert
+        assert (
+            url == "https://cdn3.amuselabs.com/atlantic/crossword"
+            "?id=atlantic_20201228&set=atlantic"
+        )

--- a/tests/test_wsj.py
+++ b/tests/test_wsj.py
@@ -1,0 +1,14 @@
+import xword_dl
+
+
+class TestWsjDownloader:
+    def test_find_solver_simple(self):
+        # Arrange
+        downloader = xword_dl.WSJDownloader()
+        url = "https://example.com/puzzles/crossword/123"
+
+        # Act
+        url = downloader.find_solver(url)
+
+        # Assert
+        assert url == "https://example.com/puzzles/crossword/123"

--- a/tests/test_xword_dl.py
+++ b/tests/test_xword_dl.py
@@ -1,0 +1,25 @@
+import pytest
+
+import xword_dl
+
+
+def test_remove_invalid_chars_from_filename():
+    # Arrange
+    invalid_filename = r'<my> filename:"/\|?*'
+
+    # Act
+    filename = xword_dl.remove_invalid_chars_from_filename(invalid_filename)
+
+    # Assert
+    assert filename == "my filename"
+
+
+class TestBaseDownloader:
+    def test_find_solver(self):
+        # Arrange
+        downloader = xword_dl.BaseDownloader()
+        url = "https://example.com"
+
+        # Act / Assert
+        with pytest.raises(NotImplementedError):
+            downloader.find_solver(url)

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -28,7 +28,7 @@ def save_puzzle(puzzle, filename):
         print("Not saving: a file named {} already exists.".format(filename))
 
 def remove_invalid_chars_from_filename(filename):
-    invalid_chars = '<>:"/\|?*'
+    invalid_chars = r'<>:"/\|?*'
 
     for char in invalid_chars:
         filename = filename.replace(char, '')


### PR DESCRIPTION
Hi! I saw you were asking about unit testing on [Twitter](https://twitter.com/xor/status/1342963298111610881) and thought it might be useful to see an example of how it can be set up, with a few test cases, so you can experiment and add some more yourself.

I'll have a go explaining what's going on here, and feel free to ask any questions!

# Run locally

This PR adds some unit tests that can be run with pytest. To run locally:

```sh
pip install pytest  # install the test runner
pip install -e .  # install xword-dl locally in "editable" mode, only need to do this once
pytest  # run the tests!
# now write more code and/or tests
pytest  # run the tests again!
```

# CI

This PR also has config to run these tests on GitHub Actions. That means future PRs will have tests run too, which is one of the best things of unit tests: when you fix something, add a test for it, and then you've got a safety net that future changes won't cause surprise regressions and break things.

It tests on all of Python 3.5-3.9 (3.4 isn't available), on Ubuntu, macOS and Windows. For example:

https://github.com/hugovk/xword-dl/actions/runs/449400063

The CI also sends something called "coverage" to a free (for open source) service called Codecov. This shows us the lines of code that were actually run when running tests, and can help us see what bits of code aren't yet tested. For example:

https://codecov.io/gh/hugovk/xword-dl/src/d2a55829efdb84963b531e7f98d7981cfd3ee188/xword_dl.py

# Tests

The idea of unit tests is to test your code in isolation, where you're testing the "units" of your code, typically functions or classes, and not a full end-to-end "integration test". A good thing about them is they run fast and don't rely on, for example, any network resources. There's still place for integration tests, but unit tests can be very useful.

# File structure

Test files are in a `tests/` directory and begin with `test_`. They could all be one big file, but I've split them up for clarity.

* `test_xword_dl.py` is for testing any global functions like `remove_invalid_chars_from_filename()` and `TestBaseDownloader` class
* `test_amuselabs.py` for classes based on `AmuseLabsDownloader`
* `test_wsj.py` for the `WSJDownloader` class
* and other files can be added for the other classes

# Test structure

I like to keep tests very simple. We want to throw some input at a function, then check the output is as expected. I use "Arrange/Act/Assert" to explicitly group each bit of the test to make it very clear  what's going on.

* Arrange: here we set up any data or objects we're going to need for the test
* Act: here we actually run the code under test and grab the output
* Arrange: finally, we usually want to check the output is something sensible

Here's one:

```python
def test_remove_invalid_chars_from_filename():
    # Arrange
    invalid_filename = r'<my> filename:"/\|?*'

    # Act
    filename = xword_dl.remove_invalid_chars_from_filename(invalid_filename)

    # Assert
    assert filename == "my filename"
```

These test functions should begin `test_`.

With the Python `unittest` module, there's a whole bunch of [assert methods](https://docs.python.org/3/library/unittest.html#assert-methods) like `assertEqual()`, `assertTrue()` and `assertFalse()`.

But we're using pytest, and most of the time just `assert` something: `assert x == y`, `assert x`, `assert not x`.

I used one special one called `pytest.raises()` to check a base downloader method isn't implemented:

```python
class TestBaseDownloader:
    def test_find_solver(self):
        # Arrange
        downloader = xword_dl.BaseDownloader()
        url = "https://example.com"

        # Act / Assert
        with pytest.raises(NotImplementedError):
            downloader.find_solver(url)
```

You can see in this one I put it in a class too, to collect together tests for a given base class too (similar to [Thea's guide](https://blog.thea.codes/my-python-testing-style-guide/)). This isn't a must, but can help keep things grouped neatly.

# Mocking

In a perfect world, we shouldn't be running anyone else's imported code, and replacing it with mocked or fake stubs. Pragmatically, I often don't worry about that for the stdlib, and we're also using `puz` here too. I think that's probably okay.

One thing I'd avoid testing is anything that makes network calls like `requests`. We don't want to make slow network calls, they can be flaky and fail if there's a temporary network problem, and it's not good to hit a third-party API/site too often.

A few options:

* Don't test stuff hitting the network
* Refactor non-network parts into another function; test that
* Mock the network request: this involves writing a fake version of, say, `requests.get(url)` to return an example of what it would return in real life 

I think there's enough here already so didn't include it here, but let me know and I can make an example of that too!

# Run locally with coverage

One last thing, you can also check coverage when running locally using a plugin and some switches:

```sh
pip install pytest pytest-cov # install the test runner and its coverage plugin
pip install -e .  # as before
# run the tests:
# tell it to check coverage of production and tests code
# and show a summary in the terminal
# and generate html output
pytest --cov xword_dl --cov tests --cov-report term --cov-report html
open htmlcov/index.html  # check the results!
```