### PR TITLE
Bump for new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # xword-dl
 
-`xword-dl` is a command-line tool to download .puz files for online crossword puzzles. For a supported outlet, you can easily download the latest puzzle, or specify one from the archives.
+`xword-dl` is a command-line tool to download .puz files for online crossword puzzles from supported outlets or arbitrary URLs. For a supported outlet, you can easily download the latest puzzle, or specify one from the archives.
 
 Currently, `xword-dl` supports:
-* The Atlantic
-* The LA Times
-* The New Yorker
+* Atlantic
+* LA Times
+* New Yorker
 * Newsday
 * USA Today
 * Universal
-* The Wall Street Journal
-* The Washington Post
+* Wall Street Journal
+* Washington Post
 
 To download a puzzle, install `xword-dl` and run it on the command line.
 
@@ -48,6 +48,12 @@ To download the Newsday Saturday Stumper and save it as `stumper.puz`, you could
 
 ```
 xword-dl nd --date saturday --output stumper
+```
+
+You can also download puzzles that are embedded in AmuseLabs solvers or on supported sites by providing a URL, such as:
+
+```
+xword-dl https://rosswordpuzzles.com/2021/01/03/cover-up/
 ```
 
 The resulting .puz file can be opened with [`cursewords`](https://github.com/thisisparker/cursewords) or any other puz file reader.

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -57,7 +57,7 @@ def by_url(url, filename=None):
     dl = None
 
     supported_downloader = next((site[1] for site in supported_sites
-                                if site[0] in netloc), None)
+                                 if site[0] in netloc), None)
 
     if supported_downloader:
         dl = supported_downloader()

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -477,27 +477,17 @@ class WSJDownloader(BaseDownloader):
         self.headers = {'User-Agent': 'xword-dl'}
 
     def find_latest(self):
-        url = "https://www.wsj.com/news/types/crossword"
+        url = "https://www.wsj.com/news/puzzle"
 
-        headlines = ''
-        attempts = 5
+        res = requests.get(url, headers=self.headers)
+        soup = BeautifulSoup(res.text, 'html.parser')
 
-        while attempts and not headlines:
-            res = requests.get(url, headers=self.headers)
-            soup = BeautifulSoup(res.text, 'html.parser')
-            headlines = soup.find('main').find('h3')
-
-            if headlines:
+        for article in soup.find_all('article'):
+            if 'crossword' in article.find('span').get_text().lower():
+                latest_url = article.find('a').get('href')
                 break
-            else:
-                print('Unable to find latest puzzle. Trying again.',
-                      file=sys.stderr)
-                time.sleep(2)
-                attempts -= 1
         else:
-            raise Exception('Unable to find latest puzzle.')
-
-        latest_url = headlines.find('a').get('href', None)
+            raise ValueError('Unable to find latest puzzle.')
 
         return latest_url
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -52,7 +52,8 @@ def by_url(url, filename=None):
     netloc = urllib.parse.urlparse(url).netloc
 
     supported_sites = [('wsj.com', WSJDownloader),
-                       ('newyorker.com', NewYorkerDownloader)]
+                       ('newyorker.com', NewYorkerDownloader),
+                       ('amuselabs.com', AmuseLabsDownloader)]
 
     dl = None
 
@@ -80,7 +81,7 @@ def by_url(url, filename=None):
     if dl:
         puzzle = dl.download(puzzle_url)
     else:
-        raise ValueError('Unable to find a puzzle at {}'.format(url))
+        raise ValueError('Unable to find a puzzle at {}.'.format(url))
 
     filename = filename or dl.pick_filename(puzzle)
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -69,7 +69,7 @@ def by_url(url, filename=None):
         soup = BeautifulSoup(res.text, 'html.parser')
 
         for iframe in soup.find_all('iframe'):
-            src = iframe.get('src')
+            src = iframe.get('src', '')
             if 'amuselabs.com' in src:
                 amuse_url = src
                 break

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -116,7 +116,7 @@ def save_puzzle(puzzle, filename):
 
 
 def remove_invalid_chars_from_filename(filename):
-    invalid_chars = '<>:"/\|?*'
+    invalid_chars = '<>"/\|?*'
 
     for char in invalid_chars:
         filename = filename.replace(char, '')

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -73,7 +73,7 @@ def parse_date_or_exit(entered_date):
     guessed_dt = parse_date(entered_date)
 
     if not guessed_dt:
-        sys.exit('Unable to determine a date from "{}".'.format(entered_date))
+        raise ValueError('Unable to determine a date from "{}".'.format(entered_date))
 
     return guessed_dt
 
@@ -169,7 +169,7 @@ class AmuseLabsDownloader(BaseDownloader):
                         if 'window.rawc' in line), None)
 
         if not rawc:
-            sys.exit("Crossword puzzle not found.")
+            raise Exception("Crossword puzzle not found.")
 
         rawc = rawc.split("'")[1]
 
@@ -387,7 +387,7 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         res = requests.get(url)
 
         if res.status_code == 404:
-            sys.exit('Unable to find a puzzle at {}'.format(url))
+            raise ConnectionError('Unable to find a puzzle at {}'.format(url))
  
         soup = BeautifulSoup(res.text, "html.parser")
 
@@ -448,7 +448,7 @@ class WSJDownloader(BaseDownloader):
                 time.sleep(2)
                 attempts -= 1
         else:
-            sys.exit('Unable to find latest puzzle.')
+            raise Exception('Unable to find latest puzzle.')
 
         latest_url = headlines.find('a').get('href', None)
 
@@ -564,7 +564,7 @@ class AMUniversalDownloader(BaseDownloader):
                 time.sleep(2)
                 attempts -= 1
         else:
-            sys.exit('Unable to download puzzle data.')
+            raise Exception('Unable to download puzzle data.')
         return xword_data
 
     def process_clues(self, clue_list):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -6,6 +6,7 @@ import datetime
 import inspect
 import json
 import os
+import shlex
 import sys
 import textwrap
 import time
@@ -62,9 +63,13 @@ def get_help_text_formatted_list():
 def save_puzzle(puzzle, filename):
     if not os.path.exists(filename):
         puzzle.save(filename)
-        print("Puzzle downloaded and saved as {}.".format(filename))
+        msg = ("Puzzle downloaded and saved as {}.".format(filename)
+                if sys.stdout.isatty()
+                else filename)
+        print(msg)
     else:
-        print("Not saving: a file named {} already exists.".format(filename))
+        print("Not saving: a file named {} already exists.".format(filename),
+                file=sys.stderr)
 
 def remove_invalid_chars_from_filename(filename):
     invalid_chars = '<>:"/\|?*'
@@ -84,7 +89,6 @@ def parse_date_or_exit(entered_date):
         raise ValueError('Unable to determine a date from "{}".'.format(entered_date))
 
     return guessed_dt
-
 
 class BaseDownloader:
     def __init__(self):
@@ -452,7 +456,8 @@ class WSJDownloader(BaseDownloader):
             if headlines:
                 break
             else:
-                print('Unable to find latest puzzle. Trying again.')
+                print('Unable to find latest puzzle. Trying again.',
+                        file=sys.stderr)
                 time.sleep(2)
                 attempts -= 1
         else:
@@ -568,7 +573,8 @@ class AMUniversalDownloader(BaseDownloader):
                 xword_data = res.json()
                 break
             except json.JSONDecodeError:
-                print('Unable to download puzzle data. Trying again.')
+                print('Unable to download puzzle data. Trying again.',
+                        file=sys.stderr)
                 time.sleep(2)
                 attempts -= 1
         else:

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -19,7 +19,7 @@ from bs4 import BeautifulSoup
 from html2text import html2text
 from unidecode import unidecode
 
-__version__ = '2020.12.30'
+__version__ = '2021.1.3'
 
 
 def by_keyword(keyword, date=None, filename=None):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -6,7 +6,6 @@ import datetime
 import inspect
 import json
 import os
-import shlex
 import sys
 import textwrap
 import time

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -406,7 +406,8 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         index_res = requests.get(index_url)
         index_soup = BeautifulSoup(index_res.text, "html.parser")
 
-        latest_fragment = next(a for a in index_soup.findAll('a') if a.find('h4'))['href']
+        latest_fragment = next(a for a in index_soup.findAll('a')
+                                    if a.find('h4'))['href']
         latest_absolute = urllib.parse.urljoin('https://www.newyorker.com',
                                                 latest_fragment)
 
@@ -682,21 +683,24 @@ class UniversalDownloader(AMUniversalDownloader):
 
 
 def main():
-    parser = argparse.ArgumentParser(prog='xword-dl', description=textwrap.dedent("""\
+    parser = argparse.ArgumentParser(prog='xword-dl',
+                                     description=textwrap.dedent("""\
         xword-dl is a tool to download online crossword puzzles and save them
-        locally as AcrossLite-compatible .puz files. It only works with
-        supported sites, a list of which is found below.
+        locally as AcrossLite-compatible .puz files. It works with supported
+        sites, a list of which can be found below.
 
         By default, xword-dl will download the most recent puzzle available at
-        a given outlet, but some outlets support specifying by date.
+        a given outlet, and some outlets support searching by date.
         """),
         formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('-v', '--version', action='version', version=__version__)
 
     parser.add_argument('source', nargs="?", help=textwrap.dedent("""\
-                                specify an outlet from which to download a puzzle.
-                                Supported keywords and outlets are:\n""") +
+                                specify a URL or a keyword to select an
+                                outlet from which to download a puzzle.
+
+                                Supported outlet keywords are:\n""") +
                                 "{}".format(get_help_text_formatted_list()))
 
     selector = parser.add_mutually_exclusive_group()
@@ -724,7 +728,8 @@ def main():
 
     try:
         if args.source.startswith('http'):
-            puzzle, filename = by_url(args.source)
+            puzzle, filename = by_url(args.source,
+                                          filename=args.output)
         else:
             puzzle, filename = by_keyword(args.source,
                                           date=''.join(args.date),

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -54,7 +54,7 @@ def get_supported_outlets():
 
 def get_help_text_formatted_list():
     text = ''
-    for d in get_supported_outlets():
+    for d in sorted(get_supported_outlets(), key=lambda x: x[1].outlet.lower()):
         text += '{:<5} {}\n'.format(d[1].command, d[1].outlet)
 
     return text

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -78,7 +78,7 @@ def by_url(url, filename=None):
             puzzle_url = amuse_url
 
     if dl:
-        dl.download(puzzle_url)
+        puzzle = dl.download(puzzle_url)
     else:
         raise ValueError('Unable to find a puzzle at {}'.format(url))
 

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -663,10 +663,6 @@ def main():
 
     parser.add_argument('-v', '--version', action='version', version=__version__)
 
-    # I don't remember why this was in here, but it probably shouldn't be
-    # parser.add_argument('url', nargs="?",
-    #                        help='URL of puzzle to download')
-
     parser.add_argument('keyword', nargs="?", help=textwrap.dedent("""\
                                 specify an outlet from which to download a puzzle.
                                 Supported keywords and outlets are:\n""") +

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -446,7 +446,8 @@ class WSJDownloader(BaseDownloader):
 
         fetched = {}
         for field in ['title', 'byline', 'publisher']:
-            fetched[field] = html2text(xword_metadata.get(field, ''), bodywidth=0).strip()
+            fetched[field] = html2text(xword_metadata.get(field, ''),
+                                       bodywidth=0).strip()
 
         puzzle = puz.Puzzle()
         puzzle.title = fetched.get('title')
@@ -541,12 +542,16 @@ class AMUniversalDownloader(BaseDownloader):
         return clue_list
 
     def parse_xword(self, xword_data):
+        fetched = {}
+        for field in ['Title', 'Author', 'Editor', 'Copryight']:
+            fetched[field] = urllib.parse.unquote(xword_data.get(field, '')).strip()
+
         puzzle = puz.Puzzle()
-        puzzle.title = xword_data.get('Title', '')
-        puzzle.author = ''.join([xword_data.get('Author', ''),
+        puzzle.title = fetched.get('Title', '')
+        puzzle.author = ''.join([fetched.get('Author', ''),
                                        ' / Ed. ',
-                                       xword_data.get('Editor', '')])
-        puzzle.copyright = xword_data.get('Copyright', '')
+                                       fetched.get('Editor', '')])
+        puzzle.copyright = fetched.get('Copyright', '')
         puzzle.width = int(xword_data.get('Width'))
         puzzle.height = int(xword_data.get('Height'))
 


### PR DESCRIPTION
- new `by_keyword` and `by_url` top level functions (in preparation for better embedding use)
- support for arbitrary URLs with embedded AmuseLabs solvers
- improved formatting and copy for help text
- replace explicit sys.exit() calls with errors for better error handling
- improved WSJ puzzle search
- print errors to `stderr` and output cleaner `stdout` if not in a tty