### PR TITLE
Add some flexibility to how xword-dl saves files

### DIFF
--- a/xword_dl.py
+++ b/xword_dl.py
@@ -1098,7 +1098,7 @@ def main():
         sys.exit(e)
 
     # specialcase the output file '-'
-    if options['filename'] == '-':
+    if args.output == '-':
         sys.stdout.buffer.write (puzzle.tobytes())
     else:
         if not filename.endswith('.puz'):

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -1097,10 +1097,13 @@ def main():
     except ValueError as e:
         sys.exit(e)
 
-    if not filename.endswith('.puz'):
-        filename = filename + '.puz'
-
-    save_puzzle(puzzle, filename)
+    # specialcase the output file '-'
+    if options['filename'] == '-':
+        sys.stdout.buffer.write (puzzle.tobytes())
+    else:
+        if not filename.endswith('.puz'):
+            filename = filename + '.puz'
+        save_puzzle(puzzle, filename)
 
 
 if __name__ == '__main__':

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -135,7 +135,7 @@ def save_puzzle(puzzle, filename):
 
 
 def remove_invalid_chars_from_filename(filename):
-    invalid_chars = '<>"/\|?*'
+    invalid_chars = '<>"\|?*'
 
     for char in invalid_chars:
         filename = filename.replace(char, '')

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -135,7 +135,7 @@ def save_puzzle(puzzle, filename):
 
 
 def remove_invalid_chars_from_filename(filename):
-    invalid_chars = '<>"\|?*'
+    invalid_chars = '<>"/\|?*'
 
     for char in invalid_chars:
         filename = filename.replace(char, '')
@@ -216,6 +216,7 @@ class BaseDownloader:
         for token in tokens.keys():
             replacement = (kwargs.get(token) if token in kwargs
                            else tokens[token])
+            replacement = remove_invalid_chars_from_filename(replacement)
             template = template.replace('%' + token, replacement)
 
 
@@ -228,9 +229,7 @@ class BaseDownloader:
         if not template.endswith('.puz'):
             template += '.puz'
 
-        filename = remove_invalid_chars_from_filename(template)
-
-        return filename
+        return template
 
     def find_solver(self, url):
         """Given a URL for a puzzle, returns the essential 'solver' URL.


### PR DESCRIPTION
This will let you save into other directories (eg. 'xword-dl -o /tmp/temp.puz') as well as let you output the .puz file directly to stdout.