### PR TITLE
Support New York Times Syndicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently, `xword-dl` supports:
 * Daily Beast (db)
 * Los Angeles Times (lat)
 * New York Times (nyt)
+* New York Times Syndicate (nyts)
 * New Yorker (tny)
 * Newsday (nd)
 * USA Today (usa)

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -1043,6 +1043,140 @@ class NewYorkTimesDownloader(BaseDownloader):
         return super().pick_filename(puzzle, title=title, **kwargs)
 
 
+class NewYorkTimesSyndicatedDownloader(BaseDownloader):
+    command = 'nyts'
+    outlet = 'New York Times Syndicated'
+    outlet_prefix = 'NY Times Syndicated'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.url_from_id = 'https://nytsyn.pzzl.com/nytsyn-crossword-mh/nytsyncrossword?date={}'
+
+        self.headers = {}
+        self.cookies = {}
+
+    def find_latest(self):
+        dt = datetime.datetime.today()
+        return self.find_by_date(dt)
+
+    def find_by_date(self, dt):
+        formatted_date = dt.strftime('%y%m%d')
+        self.date = dt
+        return self.url_from_id.format(formatted_date)
+
+    def find_solver(self, url):
+        return url
+
+    def fetch_data(self, solver_url):
+        res = requests.get(solver_url, cookies=self.cookies)
+        res.raise_for_status()
+
+        return res.text
+
+    def parse_xword(self, xword_data):
+        sections = ['note', 'title', 'authors', 'width', 'height', 'ignore', 'ignore', 'grid', 'across_clues', 'down_clues']
+        puzzle = puz.Puzzle()
+
+        lines = xword_data.split('\n')[2:]
+
+
+        fill = ''
+        solution = ''
+        clues = []
+        rebus_board = []
+        rebus_index = 0
+        rebus_table = ''
+        markup = b''
+
+        for line in lines:
+          if (len(sections) == 0):
+            break
+          if (line.strip() == ''):
+            sections.pop(0)
+            continue
+
+          section = sections[0]
+
+          if (section == 'note'):
+            original_date = datetime.datetime.strptime(line.strip(), '%y%m%d')
+            puzzle.notes = original_date.strftime('%A, %B %d, %Y')
+          elif (section == 'title'):
+            puzzle.title = line.strip()
+          elif (section == 'authors'):
+            puzzle.author = line.strip()
+          elif (section == 'width'):
+            puzzle.width = int(line.strip())
+          elif (section == 'height'):
+            puzzle.height = int(line.strip())
+          elif (section == 'grid'):
+            row = line.strip()
+            i = 0
+            while i < len(row):
+              if (row[i] == '#'):
+                  fill += '.'
+                  solution += '.'
+                  markup += b'\x00'
+                  rebus_board.append(0)
+              elif (row[i] == '%'):
+                  markup += b'\x80'
+              elif (i + 1 < len(row) and row[i+1] == ','):
+                  # rebus is formatted as letters with commas between the word
+                  fill += '-'
+                  solution += row[i]
+                  markup += b'\x00'
+
+                  rebus_word = ''
+                  while True:
+                      if (row[i] == ','):
+                        i += 1
+                        continue
+                      else:
+                        rebus_word += row[i]
+                        i += 1
+                        if (row[i] != ','):
+                          break
+                  rebus_board.append(rebus_index + 1)
+                  rebus_table += '{:2d}:{};'.format(rebus_index, rebus_word)
+                  rebus_index += 1
+                  continue
+              else:
+                  fill += '-'
+                  solution += row[i]
+                  rebus_board.append(0)
+                  if (i == 0 or row[i-1] != '%'):
+                      markup += b'\x00'
+              i+=1
+          elif (section == 'across_clues' or section == 'down_clues'):
+            clues.append(line.strip())
+
+
+        puzzle.fill = fill
+        puzzle.solution = solution
+        puzzle.clues = clues
+
+        if b'\x80' in markup:
+            puzzle.extensions[b'GEXT'] = markup
+            puzzle._extensions_order.append(b'GEXT')
+            puzzle.markup()
+
+        if any(rebus_board):
+            puzzle.extensions[b'GRBS'] = bytes(rebus_board)
+            puzzle.extensions[b'RTBL'] = rebus_table.encode(puz.ENCODING)
+            puzzle._extensions_order.extend([b'GRBS', b'RTBL'])
+            puzzle.rebus()
+
+        return puzzle
+
+    def pick_filename(self, puzzle, **kwargs):
+        if puzzle.title == self.date.strftime('%A, %B %d, %Y'):
+            title = ''
+        else:
+            title = puzzle.title
+
+        return super().pick_filename(puzzle, title=title, **kwargs)
+
+
 def main():
     parser = argparse.ArgumentParser(prog='xword-dl',
                                      description=textwrap.dedent("""\

--- a/xword_dl.py
+++ b/xword_dl.py
@@ -1080,7 +1080,6 @@ class NewYorkTimesSyndicatedDownloader(BaseDownloader):
 
         lines = xword_data.split('\n')[2:]
 
-
         fill = ''
         solution = ''
         clues = []


### PR DESCRIPTION
Supports NYT Syndicate feed by pulling from pzzl.com. For example: https://nytsyn.pzzl.com/cwd/#/s/220728. Raw data is available at https://nytsyn.pzzl.com/nytsyn-crossword-mh/nytsyncrossword?date=220728.

Fairly self-explanatory formatting.
Tested with rebus (,) by looking at https://nytsyn.pzzl.com/nytsyn-crossword-mh/nytsyncrossword?date=220522 and others
Tested with markup (%) by looking at https://nytsyn.pzzl.com/nytsyn-crossword-mh/nytsyncrossword?date=220726 

Tested output .puz files by comparing with original.