### PR TITLE
fix import of AmuseLabsDownloader

### DIFF
--- a/xword_dl/xword_dl.py
+++ b/xword_dl/xword_dl.py
@@ -75,7 +75,7 @@ def by_url(url, filename=None):
                 break
 
         if amuse_url:
-            dl = AmuseLabsDownloader(netloc=netloc)
+            dl = downloader.AmuseLabsDownloader(netloc=netloc)
             puzzle_url = amuse_url
 
     if dl:


### PR DESCRIPTION
Hi @thisisparker 👋🏼 

While trying to download crosswords[^1] from McKinsey's [*The McKinsey Crossword*](https://www.mckinsey.com/featured-insights/the-mckinsey-crossword) I noticed a possible **bug** in line [78](https://github.com/thisisparker/xword-dl/blob/89bfffea9933958f8e38134753b7479cd9263ec1/xword_dl/xword_dl.py#L78) of [`xword_dl.py`](https://github.com/thisisparker/xword-dl/blob/89bfffea9933958f8e38134753b7479cd9263ec1/xword_dl/xword_dl.py#L78).

```python
#   downloader. -> required for import
dl = AmuseLabsDownloader(netloc=netloc)
```

Afterwards I managed to successfully **download** crosswords with:

```bash
 xword-dl https://www.mckinsey.com/featured-insights/the-mckinsey-crossword/november-8-2022
```

I also tried to write a **downloader** class for *The McKinsey Crossword* however I **failed** to find the *date picker* page used by the downloaders for [*The Atlantic*](https://github.com/thisisparker/xword-dl/blob/89bfffea9933958f8e38134753b7479cd9263ec1/xword_dl/downloader/atlanticdownloader.py#L13) or [*The Daily Beast*](https://github.com/thisisparker/xword-dl/blob/89bfffea9933958f8e38134753b7479cd9263ec1/xword_dl/downloader/dailybeastdownloader.py#L15).

According to the *help* modal screen of the crossword UI *McKinsey* apparently uses the id *mck* at Amuselabs. Unfortunately using *mck* or *mckinsey* returned a 404 error when trying to access the *date picker* screen (
`https://cdn3.amuselabs.com/ID/date-picker?set=ID`).

Regards,
Petra


*I'm not affiliated with any of the organizations named above.*

[^1]: using Amuselabs *PuzzleMe*