### PR TITLE
Change GPL dependencies to MIT-compatible counterparts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dateparser==1.1.4
 html2text==2020.1.16
 puzpy==0.2.5
 requests==2.28.1
-Unidecode==1.3.6
+anyascii-0.3.1
 pyyaml==6.0
 xmltodict==0.13.0
 lxml==4.9.2


### PR DESCRIPTION
The Unidecode and html2text dependencies are GPL2 and GPL3 licensed, so they are not compatible with the MIT licensing of this project as a whole. See #61 