### PR TITLE
drop bs4 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 beautifulsoup4==4.11.1
-bs4==0.0.1
 dateparser==1.1.4
 html2text==2020.1.16
 puzpy==0.2.5


### PR DESCRIPTION
bs4 is a [dummy module](https://pypi.org/project/bs4/), and we already include the real one here ([beautifulsoup4](https://pypi.org/project/beautifulsoup4/)), so drop it.