### PR TITLE
fix selection of amuselabs iframe of The McKinsey Crossword

### DIFF
--- a/xword_dl/downloader/mckinseydownloader.py
+++ b/xword_dl/downloader/mckinseydownloader.py
@@ -59,7 +59,10 @@ class McKinseyDownloader(AmuseLabsDownloader):
 
         soup = BeautifulSoup(res.text, "html.parser")
 
-        iframe_tag = soup.select('#divArticleBody iframe[name="mckinsey"]')
+        iframe_tag = soup.select('iframe[src*="amuselabs.com"]')
+
+        if len(iframe_tag) == 0:
+            raise XWordDLException('Cannot find puzzle iframe node at {}.'.format(url))
 
         iframe_url = str(iframe_tag[0].get('src'))
 


### PR DESCRIPTION
Hi @thisisparker 

I just noticed that McKinsey has slightly adapted the frontend of *The McKinsey Crossword*.
This caused the download to fail. I slightly adapted the css selector required to identify the amuselabs iframe node.

Regards,
Petra
