### PR TITLE
Fix date guesser for atlantic puzzles

### DIFF
--- a/xword_dl/downloader/atlanticdownloader.py
+++ b/xword_dl/downloader/atlanticdownloader.py
@@ -20,5 +20,11 @@ class AtlanticDownloader(AmuseLabsDownloader):
         return self.find_puzzle_url_from_id(self.id)
 
     def guess_date_from_id(self, puzzle_id):
-        self.date = datetime.datetime.strptime(puzzle_id.split('_')[1],
+        try:
+            self.date = datetime.datetime.strptime(puzzle_id.split('_')[1],
                                                '%Y%m%d')
+        # New "Caleb's Inferno" puzzles may have a different ID format
+        # with no way to guess date. At least for now, no underscore means
+        # we can identify these by this IndexError.
+        except IndexError:
+            pass


### PR DESCRIPTION
Regular Atlantic puzzles have a predictable ID from which we can deduce the puzzle date, but the new [Caleb's Inferno](https://www.theatlantic.com/calebs-inferno-crossword-puzzle/) puzzle does not. This fixes a crash when encountering one of those puzzles.