### PR TITLE
Explicitly define encoding as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'requirements.txt')) as f:
+with open(os.path.join(here, 'requirements.txt'), encoding="utf-8") as f:
     reqs = f.read().split()
 
-with open(os.path.join(here, 'README.md')) as f:
+with open(os.path.join(here, 'README.md'), encoding="utf-8") as f:
     readme = f.read()
 
 with open(os.path.join(here, 'xword_dl', 'version')) as f:


### PR DESCRIPTION
Working toward solving #115 

On Windows 11, using Powershell, VS Code, and Python 3.11.5. Ran into exceptions into setup.py while playing around. On windows, open() defaults to cp1252 instead of utf-8. :-( Just starting with the project and this was the first thing I encountered. I suspect @thisisparker uses Mac or Linux. 