### PR TITLE
NYT: Return plain markup type for black squares

### DIFF
--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -150,7 +150,7 @@ class NewYorkTimesDownloader(BaseDownloader):
                 rebus_table += '{:2d}:{};'.format(rebus_index, square['answer'])
                 rebus_index += 1
 
-            markup += (b'\x00' if square.get('type') == 1 else b'\x80')
+            markup += (b'\x00' if square.get('type', 1) == 1 else b'\x80')
 
         puzzle.solution = solution
         puzzle.fill = fill


### PR DESCRIPTION
I've deliberately been pretty liberal with what gets the "circled" markup on NYT puzzles, because they have more `type`s than the .puz spec and it seems worse to silently drop highlighted squares. But that has inadvertently resulted in the circled markup getting applied to black squares, which could create some subtle bugs in solving clients.