### PR TITLE
NYTV: remove Variety download-by-latest and download-by-url options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported outlets:
 |*The Modern Crossword*|`mod`|✔️|✔️|✔️|
 |*New York Times*|`nyt`|✔️|✔️|✔️|
 |*New York Times Mini*|`nytm`|✔️|✔️|✔️|
-|*New York Times Variety*|`nytv`|✔️|✔️|✔️|
+|*New York Times Variety*|`nytv`||✔️||
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*Newsday*|`nd`|✔️|✔️||
 |*Universal*|`uni`|✔️|✔️||

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -192,24 +192,6 @@ class NewYorkTimesVarietyDownloader(NewYorkTimesDownloader):
 
         self.url_from_date = 'https://www.nytimes.com/svc/crosswords/v6/puzzle/variety/{}.json'
 
-    @staticmethod
-    def matches_url(url_components):
-        return ('nytimes.com' in url_components.netloc
-                    and 'variety' in url_components.path)
-
-    def find_latest(self):
-        latest_puzzles = 'https://www.nytimes.com/svc/crosswords/v3/puzzles.json?format_type=pdf%2Cnormal%2Cdiagramless&publish_type=variety%2Cassorted&sort_order=asc&sort_by=print_date&date_start={}&date_end={}'
-
-        today_string = datetime.datetime.today().strftime('%Y-%m-%d')
-        a_while_back = (datetime.datetime.today()
-                            - datetime.timedelta(days=90)).strftime('%Y-%m-%d')
-
-        res = requests.get(latest_puzzles.format(a_while_back, today_string))
-        normal_puzzles = [p for p in res.json()['results']
-                                if p['format_type'] == 'Normal']
-
-        return self.url_from_date.format(normal_puzzles[-1]['print_date'])
-
     def parse_xword(self, xword_data):
         try:
             return super().parse_xword(xword_data)


### PR DESCRIPTION
Technically you can still download by date, if you know the date to pick!