### PR TITLE
the modern: fix typo in initialize function

### DIFF
--- a/xword_dl/downloader/puzzlesocietydownloader.py
+++ b/xword_dl/downloader/puzzlesocietydownloader.py
@@ -13,7 +13,7 @@ class TheModernDownloader(CrosswordCompilerDownloader):
     outlet = 'The Modern'
     outlet_prefix = 'The Modern'
 
-    def init(self, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     @staticmethod


### PR DESCRIPTION
Debugging this one went quickly from "why doesn't this work?" to "why did this ever work?" but all good now