### PR TITLE
centralize encoding cleanup and add emoji processing step

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.12.2
 dateparser==1.1.8
+emoji==2.9.0
 html2text==2020.1.16
 puzpy==0.2.5
 requests==2.31.0

--- a/xword_dl/downloader/amuniversaldownloader.py
+++ b/xword_dl/downloader/amuniversaldownloader.py
@@ -12,7 +12,7 @@ import xmltodict
 from urllib.parse import unquote
 
 from .basedownloader import BaseDownloader
-from ..util import XWordDLException, unidecode
+from ..util import XWordDLException
 
 class AMUniversalDownloader(BaseDownloader):
     def __init__(self, **kwargs):
@@ -181,7 +181,7 @@ class USATodayDownloader(BaseDownloader):
         xw_clues = sorted(list(xw['across'].values()) + list(xw['down'].values()),
                           key=lambda c: int(c['@cn']))
 
-        puzzle.clues = [unidecode(unquote(c.get('@c') or '')) for c in xw_clues]
+        puzzle.clues = [unquote(c.get('@c') or '') for c in xw_clues]
 
         return puzzle
 

--- a/xword_dl/downloader/amuselabsdownloader.py
+++ b/xword_dl/downloader/amuselabsdownloader.py
@@ -9,7 +9,6 @@ import requests
 import re
 
 from bs4 import BeautifulSoup
-from html2text import html2text
 
 from .basedownloader import BaseDownloader
 from ..util import *
@@ -189,9 +188,9 @@ class AmuseLabsDownloader(BaseDownloader):
 
     def parse_xword(self, xword_data):
         puzzle = puz.Puzzle()
-        puzzle.title = unidecode(xword_data.get('title', '').strip())
-        puzzle.author = unidecode(xword_data.get('author', '').strip())
-        puzzle.copyright = unidecode(xword_data.get('copyright', '').strip())
+        puzzle.title = xword_data.get('title', '').strip()
+        puzzle.author = xword_data.get('author', '').strip()
+        puzzle.copyright = xword_data.get('copyright', '').strip()
         puzzle.width = xword_data.get('w')
         puzzle.height = xword_data.get('h')
 
@@ -242,9 +241,7 @@ class AmuseLabsDownloader(BaseDownloader):
 
         clues = [word['clue']['clue'] for word in weirdass_puz_clue_sorting]
 
-        normalized_clues = [html2text(unidecode(clue), bodywidth=0).strip()
-                            for clue in clues]
-        puzzle.clues.extend(normalized_clues)
+        puzzle.clues.extend(clues)
 
         has_markup = b'\x80' in markup
         has_rebus = any(rebus_board)

--- a/xword_dl/downloader/basedownloader.py
+++ b/xword_dl/downloader/basedownloader.py
@@ -97,4 +97,8 @@ class BaseDownloader:
         xword_data = self.fetch_data(solver_url)
         puzzle = self.parse_xword(xword_data)
 
+        puzzle = sanitize_for_puzfile(puzzle,
+                                      preserve_html=self.settings.get(
+                                                        'preserve_html'))
+
         return puzzle

--- a/xword_dl/downloader/compilerdownloader.py
+++ b/xword_dl/downloader/compilerdownloader.py
@@ -3,7 +3,6 @@ import requests
 import xmltodict
 
 from .basedownloader import BaseDownloader
-from ..util import unidecode
 
 class CrosswordCompilerDownloader(BaseDownloader):
     def __init__(self, **kwargs):
@@ -39,9 +38,9 @@ class CrosswordCompilerDownloader(BaseDownloader):
 
         puzzle = puz.Puzzle()
 
-        puzzle.title = unidecode(xw_metadata.get('title') or '')
-        puzzle.author = unidecode(xw_metadata.get('creator') or '')
-        puzzle.copyright = unidecode(xw_metadata.get('copyright') or '')
+        puzzle.title = xw_metadata.get('title') or ''
+        puzzle.author = xw_metadata.get('creator') or ''
+        puzzle.copyright = xw_metadata.get('copyright') or ''
 
         puzzle.width = int(xw_grid.get('@width'))
         puzzle.height = int(xw_grid.get('@height'))
@@ -66,7 +65,7 @@ class CrosswordCompilerDownloader(BaseDownloader):
 
         all_clues = xw_clues[0]['clue'] + xw_clues[1]['clue']
 
-        clues = [unidecode(c.get('#text')) + (f' ({c.get("@format", "")})'
+        clues = [c.get('#text') + (f' ({c.get("@format", "")})'
                     if c.get("@format") and enumeration else '') for c in
                     sorted(all_clues, key=lambda x: int(x.get('@number')))]
 

--- a/xword_dl/downloader/guardiandownloader.py
+++ b/xword_dl/downloader/guardiandownloader.py
@@ -7,7 +7,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .basedownloader import BaseDownloader
-from ..util import unidecode, XWordDLException
+from ..util import XWordDLException
 
 class GuardianDownloader(BaseDownloader):
     outlet = 'Guardian'
@@ -41,11 +41,11 @@ class GuardianDownloader(BaseDownloader):
     def parse_xword(self, xword_data):
         puzzle = puz.Puzzle()
 
-        puzzle.author = unidecode(xword_data.get('creator',{}).get('name',''))
+        puzzle.author = xword_data.get('creator', {}).get('name') or ''
         puzzle.height = xword_data.get('dimensions').get('rows')
         puzzle.width  = xword_data.get('dimensions').get('cols')
 
-        puzzle.title = unidecode(xword_data.get('name', ''))
+        puzzle.title = xword_data.get('name') or ''
 
         if not all(e.get('solution') for e in xword_data['entries']):
             puzzle.title += ' - no solution provided'
@@ -74,8 +74,7 @@ class GuardianDownloader(BaseDownloader):
         puzzle.solution = solution
         puzzle.fill = fill
 
-        clues = [unidecode(e.get('clue')) for e in
-                    sorted(xword_data.get('entries'), 
+        clues = [e.get('clue') for e in sorted(xword_data.get('entries'),
                     key=lambda x: (x.get('number'), x.get('direction')))]
 
         puzzle.clues = clues

--- a/xword_dl/downloader/newyorkerdownloader.py
+++ b/xword_dl/downloader/newyorkerdownloader.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .amuselabsdownloader import AmuseLabsDownloader
-from ..util import unidecode, XWordDLException
+from ..util import XWordDLException
 
 class NewYorkerDownloader(AmuseLabsDownloader):
     command = 'tny'
@@ -82,7 +82,7 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         desc = soup.find('meta',attrs={'property':
                                        'og:description'}).get('content', '')
         if desc.startswith(theme_supra):
-            self.theme_title = unidecode(desc[len(theme_supra):].rstrip('.'))
+            self.theme_title = desc[len(theme_supra):].rstrip('.')
 
         return self.find_puzzle_url_from_id(self.id)
         

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -5,7 +5,7 @@ import puz
 import requests
 
 from .basedownloader import BaseDownloader
-from ..util import XWordDLException, join_bylines, unidecode, update_config_file
+from ..util import XWordDLException, join_bylines, update_config_file
 
 class NewYorkTimesDownloader(BaseDownloader):
     command = 'nyt'
@@ -113,7 +113,7 @@ class NewYorkTimesDownloader(BaseDownloader):
         puzzle = puz.Puzzle()
 
         puzzle.author = join_bylines(xword_data['constructors'], "and").strip()
-        puzzle.copyright = xword_data['copyright'].strip()
+        puzzle.copyright = xword_data['copyright']
         puzzle.height = int(xword_data['body'][0]['dimensions']['height'])
         puzzle.width =  int(xword_data['body'][0]['dimensions']['width'])
 
@@ -125,7 +125,7 @@ class NewYorkTimesDownloader(BaseDownloader):
                 '%A, %B %d, %Y')
 
         if xword_data.get('notes'):
-            puzzle.notes = unidecode(xword_data.get('notes')[0]['text']).strip()
+            puzzle.notes = xword_data.get('notes')[0]['text']
 
         solution = ''
         fill = ''

--- a/xword_dl/downloader/wsjdownloader.py
+++ b/xword_dl/downloader/wsjdownloader.py
@@ -4,10 +4,9 @@ import puz
 import requests
 
 from bs4 import BeautifulSoup
-from html2text import html2text
 
 from .basedownloader import BaseDownloader
-from ..util import XWordDLException, unidecode
+from ..util import XWordDLException
 
 class WSJDownloader(BaseDownloader):
     command = 'wsj'
@@ -65,19 +64,14 @@ class WSJDownloader(BaseDownloader):
 
         self.date = datetime.datetime.strptime(date_string, '%Y/%m/%d')
 
-        fetched = {}
-        for field in ['title', 'byline', 'publisher', 'crosswordadditionalcopy']:
-            fetched[field] = unidecode(html2text(xword_metadata.get(field) or '',
-                                       bodywidth=0)).strip()
-
         puzzle = puz.Puzzle()
-        puzzle.title = fetched.get('title')
-        puzzle.author = fetched.get('byline')
-        puzzle.copyright = fetched.get('publisher')
+        puzzle.title = xword_metadata.get('title') or ''
+        puzzle.author = xword_metadata.get('byline') or ''
+        puzzle.copyright = xword_metadata.get('publisher') or ''
         puzzle.width = int(xword_metadata.get('gridsize').get('cols'))
         puzzle.height = int(xword_metadata.get('gridsize').get('rows'))
 
-        puzzle.notes = fetched.get('crosswordadditionalcopy')
+        puzzle.notes = xword_metadata.get('crosswordadditionalcopy') or ''
 
         solution = ''
         fill = ''
@@ -108,10 +102,8 @@ class WSJDownloader(BaseDownloader):
         sorted_clue_list = sorted(clue_list, key=lambda x: int(x['number']))
 
         clues = [clue['clue'] for clue in sorted_clue_list]
-        normalized_clues = [
-            html2text(unidecode(clue), bodywidth=0).strip() for clue in clues]
 
-        puzzle.clues = normalized_clues
+        puzzle.clues = clues
 
         has_markup = b'\x80' in markup
 

--- a/xword_dl/util/utils.py
+++ b/xword_dl/util/utils.py
@@ -2,8 +2,10 @@ import os
 import sys
 
 import dateparser
+import emoji
 import yaml
 
+from html2text import html2text
 # This imports the _module_ unidecode, which converts Unicode strings to
 # plain ASCII. The puz format, however, can accept Latin1, which is a larger
 # subset. So the second line tells the module to leave codepoints 128-256
@@ -45,6 +47,24 @@ def remove_invalid_chars_from_filename(filename):
 
     return filename
 
+def sanitize_for_puzfile(puzzle, preserve_html=False):
+    def cleanup(field):
+        if preserve_html:
+            field = emoji.demojize(unidecode(field)).strip()
+        else:
+            field = emoji.demojize(html2text(unidecode(field),
+                                             bodywidth=0).strip())
+        return field
+
+    puzzle.title = cleanup(puzzle.title)
+    puzzle.author = cleanup(puzzle.author)
+    puzzle.copyright = cleanup(puzzle.copyright)
+
+    puzzle.notes = cleanup(puzzle.notes)
+
+    puzzle.clues = [cleanup(clue) for clue in puzzle.clues]
+
+    return puzzle
 
 def parse_date(entered_date):
     return dateparser.parse(entered_date, settings={'PREFER_DATES_FROM':'past'})
@@ -77,4 +97,9 @@ def read_config_values(heading):
     with open(CONFIG_PATH, 'r') as f:
         config = yaml.safe_load(f) or {}
 
-    return config.get(heading, {})
+    # config file keys and command line flags use '-', python uses '_', so we
+    # replace '-' with '_' for the settings object
+    raw_subsettings = config.get(heading) or {}
+    subsettings = {k.replace('-','_'):raw_subsettings[k] for k in raw_subsettings}
+
+    return subsettings


### PR DESCRIPTION
A little refactor that touches a handful of downloaders, this change moves the "cleanup" step required for various text fields to fit into the constraints of .puz into one central location. That simplifies each downloader a bit and should help avoid bugs where new fields aren't sanitized correctly.

Along the way, we pick up a new dependency, alas. This new emoji library converts :fire: to `:fire:`. That is better for readability than just dropping the emoji, and also should be losslessly reversible client-side if desired.

Fixes #148 
Fixes #155 