### PR TITLE
mckinsey: less selector specificity but probably still enough

### DIFF
--- a/xword_dl/downloader/mckinseydownloader.py
+++ b/xword_dl/downloader/mckinseydownloader.py
@@ -43,8 +43,7 @@ class McKinseyDownloader(AmuseLabsDownloader):
         index_res = requests.get(index_url)
         index_soup = BeautifulSoup(index_res.text, "html.parser")
 
-        latest_fragment = next(a for a in index_soup.select('a.mdc-c-link-heading[href^="/featured-insights/the-mckinsey-crossword/"]')
-                               if a.find('div'))['href']
+        latest_fragment = next(a for a in index_soup.select('a[href^="/featured-insights/the-mckinsey-crossword/"]') if a.find('div'))['href']
         latest_absolute = urllib.parse.urljoin('https://www.mckinsey.com',
                                                latest_fragment)
 


### PR DESCRIPTION
McKinsey's class names have not been totally stable, but the link order seems to be. I think it's enough to grab the first one that matches this path start