### PR TITLE
{amuse,nyt}: sanitize rebus inputs

### DIFF
--- a/xword_dl/downloader/amuselabsdownloader.py
+++ b/xword_dl/downloader/amuselabsdownloader.py
@@ -225,7 +225,7 @@ class AmuseLabsDownloader(BaseDownloader):
                     solution += cell[0]
                     fill += '-'
                     rebus_board.append(rebus_index + 1)
-                    rebus_table += '{:2d}:{};'.format(rebus_index, cell)
+                    rebus_table += '{:2d}:{};'.format(rebus_index, unidecode(cell))
                     rebus_index += 1
 
         puzzle.solution = solution

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -5,7 +5,7 @@ import puz
 import requests
 
 from .basedownloader import BaseDownloader
-from ..util import XWordDLException, join_bylines, update_config_file
+from ..util import XWordDLException, join_bylines, update_config_file, unidecode
 
 class NewYorkTimesDownloader(BaseDownloader):
     command = 'nyt'
@@ -147,7 +147,7 @@ class NewYorkTimesDownloader(BaseDownloader):
                 solution += square['answer'][0]
                 fill += '-'
                 rebus_board.append(rebus_index + 1)
-                rebus_table += '{:2d}:{};'.format(rebus_index, square['answer'])
+                rebus_table += '{:2d}:{};'.format(rebus_index, unidecode(square['answer']))
                 rebus_index += 1
 
             markup += (b'\x00' if square.get('type', 1) == 1 else b'\x80')

--- a/xword_dl/util/utils.py
+++ b/xword_dl/util/utils.py
@@ -47,24 +47,27 @@ def remove_invalid_chars_from_filename(filename):
 
     return filename
 
+
+def cleanup(field, preserve_html=False):
+    if preserve_html:
+        field = unidecode(emoji.demojize(field)).strip()
+    else:
+        field = unidecode(emoji.demojize(html2text(field,
+                                         bodywidth=0))).strip()
+    return field
+
+
 def sanitize_for_puzfile(puzzle, preserve_html=False):
-    def cleanup(field):
-        if preserve_html:
-            field = emoji.demojize(unidecode(field)).strip()
-        else:
-            field = emoji.demojize(html2text(unidecode(field),
-                                             bodywidth=0).strip())
-        return field
+    puzzle.title = cleanup(puzzle.title, preserve_html)
+    puzzle.author = cleanup(puzzle.author, preserve_html)
+    puzzle.copyright = cleanup(puzzle.copyright, preserve_html)
 
-    puzzle.title = cleanup(puzzle.title)
-    puzzle.author = cleanup(puzzle.author)
-    puzzle.copyright = cleanup(puzzle.copyright)
+    puzzle.notes = cleanup(puzzle.notes, preserve_html)
 
-    puzzle.notes = cleanup(puzzle.notes)
-
-    puzzle.clues = [cleanup(clue) for clue in puzzle.clues]
+    puzzle.clues = [cleanup(clue, preserve_html) for clue in puzzle.clues]
 
     return puzzle
+
 
 def parse_date(entered_date):
     return dateparser.parse(entered_date, settings={'PREFER_DATES_FROM':'past'})


### PR DESCRIPTION
The specter of `unidecode` still haunts downloaders, as it turns out we may need to sanitize the contents of rebus squares in some cases (and at least for now, those are encoded in the individual downloader so we can't save it for later like we can the other fields.

Fixes #171 