### PR TITLE
nytimes: accommodate moreAnswers field for otherwise blank squares

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -115,6 +115,18 @@ jobs:
           NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
         run: |
           xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "aug 10, 2023"
+      - name: Test New York Times rebus special chars
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d 7/17/22
+      - name: Test New York Times blanks and circles
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/17/23"
       - name: Test New Yorker latest
         if: '!cancelled()'
         run: xword-dl tny

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -139,15 +139,21 @@ class NewYorkTimesDownloader(BaseDownloader):
                 solution += '.'
                 fill += '.'
                 rebus_board.append(0)
-            elif square and len(square['answer']) == 1:
+            elif square and len(square.get('answer','')) == 1:
                 solution += square['answer']
                 fill += '-'
                 rebus_board.append(0)
             else:
-                solution += square['answer'][0]
+                try:
+                    suitable_answer = (square.get('answer') or 
+                                        square['moreAnswers']['valid'][0])
+                except IndexError:
+                    raise XWordDLException('Unable to parse puzzle JSON. Possibly something .puz incompatible')
+
+                solution += suitable_answer[0]
                 fill += '-'
                 rebus_board.append(rebus_index + 1)
-                rebus_table += '{:2d}:{};'.format(rebus_index, square['answer'])
+                rebus_table += '{:2d}:{};'.format(rebus_index, suitable_answer)
                 rebus_index += 1
 
             markup += (b'\x00' if square.get('type', 1) == 1 else b'\x80')

--- a/xword_dl/downloader/puzzlesocietydownloader.py
+++ b/xword_dl/downloader/puzzlesocietydownloader.py
@@ -54,7 +54,7 @@ class TheModernDownloader(CrosswordCompilerDownloader):
     def parse_xword(self, xword_data):
         puzzle = super().parse_xword(xword_data, enumeration=False)
 
-        if not puzzle.author:
+        if not puzzle.author or puzzle.author.casefold().startswith('edited'):
             puzzle.author = puzzle.title[3:]
             puzzle.title = self.date.strftime('%A, %B %d, %Y')
 


### PR DESCRIPTION
In some cases, NYT puzzle data encodes squares that are canonically blank. The .puz format doesn't support blank solution answers, but fortunately in every example I've seen so far, there is a `moreAnswers` field to allow rebus entry. This is sort of kludge-y because it collapses the possible rebus answers down to the first one provided, but it is a valid file and a decent approximation.

Fixes #170
Fixes #154 