### PR TITLE
nytimes: accomodate blank clues

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -127,6 +127,12 @@ jobs:
           NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
         run: |
           xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/17/23"
+      - name: Test New York Times blank clues
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "9/27/18"
       - name: Test New Yorker latest
         if: '!cancelled()'
         run: xword-dl tny

--- a/xword_dl/downloader/newyorktimesdownloader.py
+++ b/xword_dl/downloader/newyorktimesdownloader.py
@@ -175,7 +175,7 @@ class NewYorkTimesDownloader(BaseDownloader):
         clue_list = xword_data['body'][0]['clues']
         clue_list.sort(key=lambda c: (int(c['label']), c['direction']))
 
-        puzzle.clues = [c['text'][0]['plain'] for c in clue_list]
+        puzzle.clues = [c['text'][0].get('plain') or '' for c in clue_list]
 
         return puzzle
 


### PR DESCRIPTION
If no text is provided for a clue, then put no text in! Fair enough.

Updates #175 