### PR TITLE
newyorker: move theme title handling and test

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -145,6 +145,9 @@ jobs:
       - name: Test New Yorker themed
         if: '!cancelled()'
         run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/05"
+      - name: Test New Yorker themed, special chars title
+        if: '!cancelled()'
+        run: xword-dl tny -d 1/12/24
       - name: Test Newsday latest
         if: '!cancelled()'
         run: xword-dl nd

--- a/xword_dl/downloader/newyorkerdownloader.py
+++ b/xword_dl/downloader/newyorkerdownloader.py
@@ -92,17 +92,18 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         if '<' in puzzle.title:
             puzzle.title = puzzle.title.split('<')[0]
 
+        if self.theme_title:
+            puzzle.title += f' - {self.theme_title}'
+
         return puzzle
 
     def pick_filename(self, puzzle, **kwargs):
         try:
             supra, main = puzzle.title.split(':', 1)
+            if self.theme_title:
+                main = main.rsplit(' - ')[0]
             if supra == 'The Crossword' and dateparser.parse(main):
-                if self.theme_title:
-                    title = self.theme_title
-                    puzzle.title += f' - {self.theme_title}'
-                else:
-                    title = ''
+                title = self.theme_title
             else:
                 title = main.strip()
         except XWordDLException:


### PR DESCRIPTION
Previously we'd handled the "theme title" at the filename selection phase, but that would allow edits to the puz file data after it had been sanitized. This fixes that issue and adds a CI test to catch future regressions.