### PR TITLE
wsj, base: Move requests to a session object that can accept settings

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -171,13 +171,19 @@ jobs:
         run: xword-dl vox
       - name: Test WSJ latest
         if: '!cancelled()'
-        run: xword-dl wsj
+        env:
+          DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
+        run: xword-dl wsj --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}'
       - name: Test WSJ by URL
         if: '!cancelled()'
-        run: xword-dl "https://www.wsj.com/articles/carbon-neutral-saturday-crossword-january-15-11642193133"
+        env:
+          DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
+        run: xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/carbon-neutral-saturday-crossword-january-15-11642193133"
       - name: Test WSJ Friday contest
         if: '!cancelled()'
-        run: xword-dl "https://www.wsj.com/articles/hitting-the-high-notes-friday-crossword-january-5-0f18d7c1"
+        env:
+          DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
+        run: xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/hitting-the-high-notes-friday-crossword-january-5-0f18d7c1"
       - name: Test Washington Post latest
         if: '!cancelled()'
         run: xword-dl wp

--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -173,17 +173,20 @@ jobs:
         if: '!cancelled()'
         env:
           DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
-        run: xword-dl wsj --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}'
+        run: |
+          xword-dl wsj --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}'
       - name: Test WSJ by URL
         if: '!cancelled()'
         env:
           DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
-        run: xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/carbon-neutral-saturday-crossword-january-15-11642193133"
+        run: |
+          xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/carbon-neutral-saturday-crossword-january-15-11642193133"
       - name: Test WSJ Friday contest
         if: '!cancelled()'
         env:
           DATADOME_COOKIE: ${{ secrets.DATADOME_COOKIE }}
-        run: xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/hitting-the-high-notes-friday-crossword-january-5-0f18d7c1"
+        run: |
+          xword-dl --settings '{"cookies": {"datadome":"'$DATADOME_COOKIE'"}}' "https://www.wsj.com/articles/hitting-the-high-notes-friday-crossword-january-5-0f18d7c1"
       - name: Test Washington Post latest
         if: '!cancelled()'
         run: xword-dl wp

--- a/xword_dl/downloader/basedownloader.py
+++ b/xword_dl/downloader/basedownloader.py
@@ -1,5 +1,7 @@
 import urllib
 
+import requests
+
 from ..util import *
 
 class BaseDownloader:
@@ -27,6 +29,10 @@ class BaseDownloader:
 
         if kwargs.get('filename'):
             self.settings['filename'] = kwargs.get('filename')
+
+        self.session = requests.Session()
+        self.session.headers.update(self.settings.get('headers', {}))
+        self.session.cookies.update(self.settings.get('cookies', {}))
 
     def pick_filename(self, puzzle, **kwargs):
         tokens = {'outlet':  self.outlet or '',

--- a/xword_dl/downloader/wsjdownloader.py
+++ b/xword_dl/downloader/wsjdownloader.py
@@ -25,8 +25,6 @@ class WSJDownloader(BaseDownloader):
         res = self.session.get(url)
         soup = BeautifulSoup(res.text, 'html.parser')
 
-        print(res.request.headers, res.request._cookies)
-
         exclude_urls = ['https://www.wsj.com/articles/contest-crosswords-101-how-to-solve-puzzles-11625757841']
 
         for article in soup.find_all('article'):

--- a/xword_dl/downloader/wsjdownloader.py
+++ b/xword_dl/downloader/wsjdownloader.py
@@ -1,7 +1,6 @@
 import datetime
 
 import puz
-import requests
 
 from bs4 import BeautifulSoup
 
@@ -14,9 +13,7 @@ class WSJDownloader(BaseDownloader):
     outlet_prefix = 'WSJ'
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        self.headers = {'User-Agent': 'xword-dl'}
+        super().__init__(headers={'User-Agent': 'xword-dl'}, **kwargs)
 
     @staticmethod
     def matches_url(url_components):
@@ -25,8 +22,10 @@ class WSJDownloader(BaseDownloader):
     def find_latest(self):
         url = "https://www.wsj.com/news/puzzle"
 
-        res = requests.get(url, headers=self.headers)
+        res = self.session.get(url)
         soup = BeautifulSoup(res.text, 'html.parser')
+
+        print(res.request.headers, res.request._cookies)
 
         exclude_urls = ['https://www.wsj.com/articles/contest-crosswords-101-how-to-solve-puzzles-11625757841']
 
@@ -44,7 +43,7 @@ class WSJDownloader(BaseDownloader):
         if '/puzzles/crossword/' in url:
             return url
         else:
-            res = requests.get(url, headers=self.headers)
+            res = self.session.get(url)
             soup = BeautifulSoup(res.text, 'html.parser')
             try:
                 puzzle_link = soup.find('iframe').get('src')
@@ -54,7 +53,7 @@ class WSJDownloader(BaseDownloader):
 
     def fetch_data(self, solver_url):
         data_url = solver_url.rsplit('/', maxsplit=1)[0] + '/data.json'
-        return requests.get(data_url, headers=self.headers).json()['data']
+        return self.session.get(data_url).json()['data']
 
     def parse_xword(self, xword_data):
         xword_metadata = xword_data.get('copy', '')


### PR DESCRIPTION
This change creates a requests Session object at the BaseDownloader level and loads it with the `headers` and `cookies` that are specified in a config file, as keyword arguments, or command line arguments. In part this keeps us from having to repeat ourselves in instances where we have multiple requests that require the same arguments, and it should slightly simplify the story for new downloaders.

All the old-style downloaders will continue to work, but should eventually be updated to use the Session established by the BaseDownloader. For this PR, I've updated the WSJ downloader to the new syntax in order to put together a fix for #178. I've also attempted to update the tests that it uses... we'll see!