### PR TITLE
update lxml requirement from 4.9.2 to 5.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ requests==2.31.0
 Unidecode==1.3.6
 pyyaml==6.0.1
 xmltodict==0.13.0
-lxml==4.9.2
+lxml==5.1.0


### PR DESCRIPTION
`lxml` 4.9.2, the version currently required by `xword-dl`, does not have precompiled wheels available for Python 3.12 (see https://pypi.org/project/lxml/4.9.2/#files), whereas `lxml` 4.9.3 and newer do. This commit updates the requirement for `lxml` to 5.1.0 (the latest available version) to allow for installing `xword-dl` locally under Python 3.12 without having to locally build a wheel for `lxml`.

(Thank you for your work on `xword-dl`, I use it often. 🙂)