### PR TITLE
Fix Guardian puzzle downloader

### DIFF
--- a/xword_dl/downloader/guardiandownloader.py
+++ b/xword_dl/downloader/guardiandownloader.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import re
 
 import puz
 import requests
@@ -22,7 +23,9 @@ class GuardianDownloader(BaseDownloader):
         res = requests.get(self.landing_page)
         soup = BeautifulSoup(res.text, 'html.parser')
 
-        url = soup.find('a', attrs={'data-link-name': 'article'}).get('href')
+        url = 'https://www.theguardian.com'
+        xword_link_re = re.compile(r'/crosswords/\w+/\d+')
+        url += soup.find('a', href=xword_link_re).get('href')
 
         return url
 
@@ -33,7 +36,7 @@ class GuardianDownloader(BaseDownloader):
         res = requests.get(solver_url)
         soup = BeautifulSoup(res.text, 'html.parser')
 
-        xw_data = json.loads(soup.find('div', 
+        xw_data = json.loads(soup.find('div',
                     attrs={'class':'js-crossword'}).get('data-crossword-data'))
 
         return xw_data


### PR DESCRIPTION
The attribute previously used to find puzzle links changed. Rather than update it to a new one, take the first link in the page matching the puzzle URL format, as this should be more reliable.

Fixes #190.