### PR TITLE
Add Defector crossword support

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Test Daily Beast latest
         if: '!cancelled()'
         run: xword-dl db
+      - name: Test Defector latest
+        if: '!cancelled()'
+        run: xword-dl def
       - name: Test Daily Pop latest
         if: '!cancelled()'
         run: xword-dl pop

--- a/xword_dl/downloader/defectordownloader.py
+++ b/xword_dl/downloader/defectordownloader.py
@@ -1,0 +1,12 @@
+from .amuselabsdownloader import AmuseLabsDownloader
+
+class DefectorDownloader(AmuseLabsDownloader):
+    command = 'def'
+    outlet = 'Defector'
+    outlet_prefix = 'Defector'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.picker_url = 'https://cdn3.amuselabs.com/pmm/date-picker?set=defectormedia'
+        self.url_from_id = 'https://cdn3.amuselabs.com/pmm/crossword?id={puzzle_id}&set=defectormedia'


### PR DESCRIPTION
Dates and URL support are a soupy JSON/`__NEXT_DATA__` mess and I'm not very good at Python but I'm working on it! May push to a separate draft PR if I could use some help.

However this adds basic support, a la `db`
