### PR TITLE
xword_dl: reorder iframe source check from most to least specific

### DIFF
--- a/xword_dl/xword_dl.py
+++ b/xword_dl/xword_dl.py
@@ -82,9 +82,13 @@ def parse_for_embedded_puzzle(url, **kwargs):
     res = requests.get(url, headers={'User-Agent':'xword-dl'})
     soup = BeautifulSoup(res.text, 'lxml')
 
-    sources = [urllib.parse.urljoin(url, iframe.get('src', '') or
-                iframe.get('data-crossword-url', '')) for iframe in
-                soup.find_all('iframe')]
+    sources = [urllib.parse.urljoin(url,
+                    iframe.get('data-crossword-url', '') or
+                    iframe.get('data-src', '') or
+                    iframe.get('src', ''))
+                for iframe in soup.find_all('iframe')]
+
+    sources = [src for src in sources if src != 'about:blank']
 
     sources.insert(0, url)
 


### PR DESCRIPTION
This prevents an issue where the `src` has been provided as `about:blank` and the useful data in `data-src` or a crossword specific tag is ignored (as observed with TNY Mini puzzle pages).