### PR TITLE
Added date search for Vox. To accomplish this, enhanced find_by_date …

### DIFF
--- a/xword_dl/downloader/voxdownloader.py
+++ b/xword_dl/downloader/voxdownloader.py
@@ -16,3 +16,15 @@ class VoxDownloader(AmuseLabsDownloader):
     def guess_date_from_id(self, puzzle_id):
         self.date = datetime.datetime.strptime(puzzle_id.split('_')[1],
                                                '%Y%m%d')
+
+    def find_by_date(self, dt):
+        url_formatted_date = dt.strftime('%Y%m%d')
+        authors = ['', 'PB', 'AP', 'WN', 'AOK', 'JG', 'AJR']  # The author varies by day, and their initials may or may not be present as a prefix
+        suffixes = ['1000', '1100', '1000%20(1)']  # The suffix is always one of these. I can't determine the pattern.
+        self.get_and_add_picker_token()
+        candidate_urls = []
+        for suffix in suffixes:  # On average, it will be faster to search by the most frequent suffixes first
+            for author in authors:
+                self.id = author + 'vox_' + url_formatted_date + '_' + suffix
+                candidate_urls.append(self.find_puzzle_url_from_id(self.id))
+        return candidate_urls

--- a/xword_dl/xword_dl.py
+++ b/xword_dl/xword_dl.py
@@ -43,10 +43,26 @@ def by_keyword(keyword, **kwargs):
         raise XWordDLException(
             'Selection by date not available for {}.'.format(dl.outlet))
 
-    puzzle = dl.download(puzzle_url)
+    if isinstance(puzzle_url, list):
+        puzzle = get_puzzle_from_candidate_urls(dl, puzzle_url)
+    else:
+        puzzle = dl.download(puzzle_url)
     filename = dl.pick_filename(puzzle)
 
     return puzzle, filename
+
+
+def get_puzzle_from_candidate_urls(dl, candidate_urls):
+    puzzle = None
+    for url in candidate_urls:
+        try:
+            puzzle = dl.download(url)
+            if puzzle:
+                return puzzle
+        except Exception:
+            continue
+    if not puzzle:
+        raise XWordDLException('Crossword puzzle not found.')
 
 
 def by_url(url, **kwargs):
@@ -121,7 +137,7 @@ def parse_for_embedded_puzzle(url, **kwargs):
 def get_supported_outlets(command_only=True):
     all_classes = inspect.getmembers(sys.modules['xword_dl.downloader'],
                                      inspect.isclass)
-    dls = [d for d in all_classes if issubclass(d[1], 
+    dls = [d for d in all_classes if issubclass(d[1],
                    downloader.BaseDownloader)]
 
     if command_only:


### PR DESCRIPTION
Added date search for Vox. To accomplish this, enhanced find_by_date to return a list of candidate URLs. xword_dl.py now looks to see if it was passed a candidate URL list, and if so, it attempts to find a puzzle at any of the candidate URLs.

For example, in the case of Vox, all of the puzzle URLs contain an author prefix and a numeric suffix. These prefixes and suffixes are limited in possibility. Therefore, if we build a list of all the possible combinations, it's possible to derive the correct puzzle url.

Caveats: This relies on the website being consistent in how they build these puzzle IDs. As another example, in the case of Vox, the puzzle on 2024-10-29 incorrectly used 20241028 as its date in the url. For the vast majority of puzzles, this script will work, but it is not flawless.