### PR TITLE
Gracefully skip errors having to do with bad/dead links in iframes

### DIFF
--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -83,13 +83,16 @@ def parse_for_embedded_puzzle(url: str, **kwargs):
     res = requests.get(url, headers={"User-Agent": "xword-dl"})
     page_source = res.text
 
-    for dlr in supported_downloaders:
-        puzzle_url = dlr.matches_embed_pattern(url, page_source)
-        # TODO: would it be better to just return a URL and have controller
-        # request this from the plugin via normal methods?
-        if puzzle_url is not None:
-            return (dlr(url=url, **kwargs), puzzle_url)
-
+    try:
+        for dlr in supported_downloaders:
+            puzzle_url = dlr.matches_embed_pattern(url, page_source)
+            # TODO: would it be better to just return a URL and have controller
+            # request this from the plugin via normal methods?
+            if puzzle_url is not None:
+                return (dlr(url=url, **kwargs), puzzle_url)
+    except Exception as e:
+        pass
+        # print(f"Error processing {src}: {e}")
     return None, None
 
 


### PR DESCRIPTION
In the `parse_for_embedded_puzzle` function, we get a set of `src`s from iframes.  In the event that one of these `src`s is a bad/dead link (specifically, one that comes before the embedded puzzle we're looking for), then `xword-dl` will throw an error instead of finding the correct iframe `src`.

This PR resolves this problem by putting the `requests.get(src)` in a try-catch block.