### PR TITLE
amuselabs: rename pickerToken to loadToken

### DIFF
--- a/xword_dl/downloader/amuselabsdownloader.py
+++ b/xword_dl/downloader/amuselabsdownloader.py
@@ -53,9 +53,9 @@ class AmuseLabsDownloader(BaseDownloader):
 
         if rawsps:
             picker_params = json.loads(base64.b64decode(rawsps).decode("utf-8"))
-            token = picker_params.get('pickerToken', None)
+            token = picker_params.get('loadToken', None)
             if token:
-                self.url_from_id += '&pickerToken=' + token
+                self.url_from_id += '&loadToken=' + token
 
     def find_puzzle_url_from_id(self, puzzle_id):
         return self.url_from_id.format(puzzle_id=puzzle_id)


### PR DESCRIPTION
This reflects a change that appears to have happened on AmuseLab's end. Should fix LAT, Vox, Newsday, and Daily Beast downloaders.

Fixes #218