### PR TITLE
Remove Globe and Mail from supported downloaders

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -49,12 +49,6 @@ jobs:
       - name: Test Der Standard by URL
         if: '!cancelled()'
         run: xword-dl "https://www.derstandard.at/story/3000000201583/kreuzwortraetsel-h-10580"
-      - name: Test Globe and Mail
-        if: '!cancelled()'
-        run: xword-dl tgam
-      - name: Test Globe and Mail by URL
-        if: '!cancelled()'
-        run: xword-dl "https://www.theglobeandmail.com/puzzles-and-crosswords/cryptic-crossword/?date=060124&T=0"
       - name: Test Guardian Cryptic
         if: '!cancelled()'
         run: xword-dl grdc

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Supported outlets:
 |*The Daily Beast*|`db`|✔️|||
 |*Daily Pop*|`pop`|✔️|✔️||
 |*Der Standard*|`std`|✔️||✔️|
-|*The Globe And Mail cryptic*|`tgam`|✔️|✔️|✔️|
 |*Guardian Cryptic*|`grdc`|✔️||✔️|
 |*Guardian Everyman*|`grde`|✔️||✔️|
 |*Guardian Prize*|`grdp`|✔️||✔️|

--- a/xword_dl/downloader/globeandmaildownloader.py
+++ b/xword_dl/downloader/globeandmaildownloader.py
@@ -5,7 +5,10 @@ from .compilerdownloader import CrosswordCompilerDownloader
 from ..util import XWordDLException
 
 class GlobeAndMailDownloader(CrosswordCompilerDownloader):
-    command = 'tgam'
+    #command = 'tgam'       # Removing because as of Jan 2025, TGAM has stopped publishing its own puzzle
+                            # and instead syndicates The Times on a 6 week delay.
+                            # Leaving this file because it's small and might be a useful reference for
+                            # other Compiler children.
     outlet = 'The Globe And Mail (Cryptic)'
     outlet_prefix = 'Globe And Mail'
 


### PR DESCRIPTION
This PR removes The Globe and Mail's cryptic, which was discontinued earlier this year in favor of syndicating one by The Times, and updates the Github Actions workflow and README to reflect that change.

Fixes #212 