### PR TITLE
puzzmo: add puzzmo big, and by-date and by-URL search for both

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -145,6 +145,15 @@ jobs:
       - name: Test Puzzmo latest
         if: '!cancelled()'
         run: xword-dl pzm
+      - name: Test Puzzmo Big latest
+        if: '!cancelled()'
+        run: xword-dl pzmb
+      - name: Test Puzzmo by date
+        if: '!cancelled()'
+        run: xword-dl pzm -d "2024-08-02"
+      - name: Test Puzzmo Big by date
+        if: '!cancelled()'
+        run: xword-dl pzmb -d "2025-04-21"
       - name: Test Simply Daily Puzzles
         if: '!cancelled()'
         run: xword-dl sdp

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supported outlets:
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*Newsday*|`nd`|✔️|✔️||
 |*Puzzmo*|`pzm`|✔️|||
+|*Puzzmo Big*|`pzmb`|✔️|||
 |*Simply Daily Puzzles*|`sdp`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Cryptic*|`sdpc`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Quick*|`sdpq`|✔️|✔️|✔️|

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Supported outlets:
 |*New York Times Variety*|`nytv`||✔️||
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*Newsday*|`nd`|✔️|✔️||
-|*Puzzmo*|`pzm`|✔️|✔️||
-|*Puzzmo Big*|`pzmb`|✔️|✔️||
+|*Puzzmo*|`pzm`|✔️|✔️|✔️|
+|*Puzzmo Big*|`pzmb`|✔️|✔️|✔️|
 |*Simply Daily Puzzles*|`sdp`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Cryptic*|`sdpc`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Quick*|`sdpq`|✔️|✔️|✔️|

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Supported outlets:
 |*New York Times Variety*|`nytv`||✔️||
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*Newsday*|`nd`|✔️|✔️||
-|*Puzzmo*|`pzm`|✔️|||
-|*Puzzmo Big*|`pzmb`|✔️|||
+|*Puzzmo*|`pzm`|✔️|✔️||
+|*Puzzmo Big*|`pzmb`|✔️|✔️||
 |*Simply Daily Puzzles*|`sdp`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Cryptic*|`sdpc`|✔️|✔️|✔️|
 |*Simply Daily Puzzles Quick*|`sdpq`|✔️|✔️|✔️|

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='xword_dl',
         author_email='parker@parkerhiggins.net',
         packages=find_packages(),
         package_data={'xword_dl':['version']},
-        python_requires='>=3.7',
+        python_requires='>=3.9',
         install_requires=reqs,
         entry_points={
             'console_scripts': [

--- a/xword_dl/downloader/puzzmodownloader.py
+++ b/xword_dl/downloader/puzzmodownloader.py
@@ -24,6 +24,8 @@ class PuzzmoDownloader(BaseDownloader):
 
         self.finder_key = 'today:/{date_string}/crossword'
 
+        self.date_string = ''
+
     def _get_puzzmo_date(self, dt=None):
         # Returns what "today" is for Puzzmo, right now or for a given datetime object
         if not dt:
@@ -32,6 +34,10 @@ class PuzzmoDownloader(BaseDownloader):
             dt = dt.astimezone(tz=ZoneInfo("America/New_York"))
 
         return dt if dt.hour >= 1 else dt - timedelta(days=1)
+
+    @staticmethod
+    def matches_url(url_components):
+        return ('puzzmo.com' in url_components.netloc and re.match(r"^/puzzle/\d{4}-\d{2}-\d{2}/crossword/?$", url_components.path))
 
     def find_latest(self):
         puzzmo_date = self._get_puzzmo_date()
@@ -46,6 +52,8 @@ class PuzzmoDownloader(BaseDownloader):
         return f'https://www.puzzmo.com/puzzle/{self.date_string}/crossword'
 
     def find_solver(self, url):
+        if not self.date_string:
+            self.date_string = re.search(r"(\d{4}-\d{2}-\d{2})", url).group(1)
         return url
 
     def fetch_data(self, solver_url):
@@ -225,6 +233,10 @@ class PuzzmoBigDownloader(PuzzmoDownloader):
         most_recent_even_monday = start_date + timedelta(weeks=even_weeks)
 
         return most_recent_even_monday
+
+    @staticmethod
+    def matches_url(url_components):
+        return ('puzzmo.com' in url_components.netloc and re.match(r"^/puzzle/\d{4}-\d{2}-\d{2}/crossword/big/?$", url_components.path))
 
     def find_latest(self):
         today = self._get_puzzmo_date()

--- a/xword_dl/downloader/puzzmodownloader.py
+++ b/xword_dl/downloader/puzzmodownloader.py
@@ -4,14 +4,13 @@ import secrets
 import dateparser
 import puz
 
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
 from .basedownloader import BaseDownloader
 from ..util import join_bylines, XWordDLException
 
 class PuzzmoDownloader(BaseDownloader):
-    command = 'pzm'
-    outlet = 'Puzzmo'
-    outlet_prefix = 'Puzzmo'
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -20,68 +19,54 @@ class PuzzmoDownloader(BaseDownloader):
                                         self.temporary_user_id})
 
     def find_latest(self):
-        query = """mutation PlayGameRedirectScreenMutation(
-                    $gameSlug: String!
-                    $puzzleSlug: String
-                    $temporaryUserID: String
-                    $partnerSlug: String
-                  ) {
-                    startPlayingGame(gameSlug: $gameSlug, puzzleSlug: $puzzleSlug, temporaryUserID: $temporaryUserID, partnerSlug: $partnerSlug) {
-                      slug
-                      id
-                  }
-                }"""
+        now_et = datetime.now(tz=ZoneInfo("America/New_York"))
+        puzzmo_date = now_et.date() if now_et.hour >= 1 \
+                        else now_et.date() - timedelta(days=1)
 
-        variables = {'gameSlug': 'crossword',
-                     'puzzleSlug': None,
-                     'tempraryUserID': self.temporary_user_id,
-                     'partnerSlug': None}
+        self.date_string = puzzmo_date.isoformat()
 
-        operation_name = 'PlayGameRedirectScreenMutation'
-
-        payload = {'operationName': operation_name,
-                  'query': query,
-                  'variables': variables}
-
-        redirect_res = self.session.post('https://www.puzzmo.com/_api/prod/graphql?PlayGameRedirectScreenMutation', json=payload)
-
-        slug = redirect_res.json()['data']['startPlayingGame']['slug']
-
-        return f'https://www.puzzmo.com/play/crossword/{slug}'
+        # This URL is arbitrary but it seems better to return the solving page, why not?
+        # In practice, setting the date_string above does everything we need here.
+        return f'https://www.puzzmo.com/puzzle/{self.date_string}/crossword'
 
     def find_solver(self, url):
         return url
 
     def fetch_data(self, solver_url):
-        slug = solver_url.rsplit('/')[-1] 
         query = """query PlayGameScreenQuery(
-                      $slug: ID!
+                      $finderKey: String!
+                      $gameContext: StartGameContext!
                     ) {
-                      todaysDaily {
-                        dayString
-                        id
-                      }
-                      gamePlay(id: $slug, pingOwnerForMultiplayer: true) {
-                        puzzle {
-                          name
-                          emoji
-                          puzzle
-                          author
-                          authors {
-                            username
-                            usernameID
-                            name
-                            id
+                      startOrFindGameplay(finderKey: $finderKey, context: $gameContext) {
+                        __typename
+                        ... on ErrorableResponse {
+                          message
+                          failed
+                          success
+                        }
+                        ...on HasGamePlayed {
+                          gamePlayed{
+                            puzzle {
+                              name
+                              emoji
+                              puzzle
+                              dailyTitle
+                              author
+                              authors {
+                                publishingName
+                                username
+                                usernameID
+                                name
+                                id
+                              }
+                            }
                           }
                         }
                       }
-                    }"""
+                      }"""
 
-        variables = {'gameSlug': 'crossword',
-                     'myUserStateID': self.temporary_user_id + ':userstate',
-                     'partnerSlug': None,
-                     'playerID': self.temporary_user_id + ':userstate',
-                     'slug': slug}
+        variables = {'finderKey': self.finder_key.format(date_string=self.date_string),
+                     'gameContext': {'partnerSlug': None, 'pingOwnerForMultiplayer': True}}
 
         operation_name = 'PlayGameScreenQuery'
 
@@ -91,16 +76,22 @@ class PuzzmoDownloader(BaseDownloader):
 
         res = self.session.post('https://www.puzzmo.com/_api/prod/graphql?PlayGameScreenQuery', json=payload)
 
-        self.date = dateparser.parse(
-                res.json()['data']['todaysDaily']['dayString'])
+        try:
+            xw_data = res.json()['data']['startOrFindGameplay']['gamePlayed']['puzzle']
+        except KeyError as e:
+            raise XWordDLException('Unable to extract puzzle data.')
 
-        return res.json()['data']['gamePlay']['puzzle']
+        return xw_data
 
     def parse_xword(self, xw_data):
         puzzle = puz.Puzzle()
 
+        self.date = dateparser.parse(xw_data['dailyTitle']) or \
+                    dateparser.parse(xw_data['dailyTitle'].split('-')[0])
+
         puzzle.title = xw_data.get('name','')
-        puzzle.author = join_bylines([a['name'] for a in xw_data['authors']])
+        puzzle.author = join_bylines([a.get('publishingName', a.get('name')) \
+                            for a in xw_data['authors']])
         puzzle_lines = [l.strip() for l in xw_data['puzzle'].splitlines()]
 
         section = None
@@ -190,3 +181,28 @@ class PuzzmoDownloader(BaseDownloader):
         puzzle.clues = [c[2].split(' ~ ')[0].strip() for c in clue_list]
 
         return puzzle
+
+
+class PuzzmoDailyDownloader(PuzzmoDownloader):
+    command = 'pzm'
+    outlet = 'Puzzmo'
+    outlet_prefix = 'Puzzmo'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.finder_key = 'today:/{date_string}/crossword'
+
+
+class PuzzmoBigDownloader(PuzzmoDownloader):
+    command = 'pzmb'
+    outlet = 'Puzzmo Big'
+    outlet_prefix = 'Puzzmo Big'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.finder_key = 'today:/{date_string}/crossword/big'
+
+    def find_latest(self):
+        return super().find_latest()  + '/big'


### PR DESCRIPTION
This refactors the graphql query from the existing Puzzmo downloader and adds support for Puzzmo Big. Both channels only have "latest" support, and archives would require some auth. It's possible that this will be short-lived as the Big Crossword is supposed to be going behind the paywall soon anyway!

Fixes #211.
Fixes #213.
