### PR TITLE
fixup: pass url as a kwarg to downloader from embedded solver

### DIFF
--- a/xword_dl/xword_dl.py
+++ b/xword_dl/xword_dl.py
@@ -103,7 +103,7 @@ def parse_for_embedded_puzzle(url: str, **kwargs):
             # TODO: would it be better to just return a URL and have controller
             # request this from the plugin via normal methods?
             if puzzle_url is not None:
-                return (dlr(**kwargs), puzzle_url)
+                return (dlr(url=url, **kwargs), puzzle_url)
 
     return None, None
 


### PR DESCRIPTION
The `url` value is used in the BaseDownloader constructor to set its `netloc` and to inherit settings from that value and from the `url` parent, so we should be passing it!