### PR TITLE
New Yorker: date URL is now Y-M-D (was: Y/M/D)

### DIFF
--- a/xword_dl/downloader/newyorkerdownloader.py
+++ b/xword_dl/downloader/newyorkerdownloader.py
@@ -2,6 +2,7 @@ import json
 import urllib.parse
 
 import dateparser
+import datetime
 import requests
 
 from bs4 import BeautifulSoup, Tag
@@ -32,7 +33,11 @@ class NewYorkerDownloader(AmuseLabsDownloader):
         )
 
     def find_by_date(self, dt):
-        url_format = dt.strftime("%Y/%m/%d")
+        # On 2025-07-09 New Yorker changed URL format from /Y/m/d to /Y-m-d
+        separator = '-'
+        if dt < datetime.datetime(2025, 7, 9, 0, 0, 0, 0):
+            separator = '/'
+        url_format = dt.strftime("%Y" + separator + "%m" + separator + "%d")
         guessed_url = urllib.parse.urljoin(
             "https://www.newyorker.com/puzzles-and-games-dept/crossword/", url_format
         )


### PR DESCRIPTION
As of July 9 2025, newyorker.com/puzzles-and-games-dept/crossword/ requires dashes, not slashes: /2025-07-09, not /2025/07/09

Unfortunately, this only applies to puzzles since that date. Prior puzzles are still accessed via /Y/m/d.

Update newyorkerdownloader.py:find_by_date() so it handles old and new.