### PR TITLE
publish workflow: add contents write permission

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,7 @@ jobs:
     environment: publish
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3


### PR DESCRIPTION
I believe this is necessary for the publish action to create a draft release