### PR TITLE
CompilerDownloader: return binary response from solver URL

### DIFF
--- a/src/xword_dl/downloader/compilerdownloader.py
+++ b/src/xword_dl/downloader/compilerdownloader.py
@@ -20,7 +20,7 @@ class CrosswordCompilerDownloader(BaseDownloader):
     def fetch_data(self, solver_url):
         res = self.session.get(solver_url)
 
-        return res.text
+        return res.content
 
     def parse_xword(self, xw_data, enumeration=True):
         xw = xmltodict.parse(xw_data)
@@ -99,5 +99,5 @@ class CrosswordCompilerJSEncodedDownloader(CrosswordCompilerDownloader):
 
     def fetch_data(self, solver_url):
         xw_data = super().fetch_data(solver_url)
-        xw_data = xw_data[len('var CrosswordPuzzleData = "') : -len('";')]
-        return xw_data.replace("\\", "")
+        xw_data = xw_data[len(b'var CrosswordPuzzleData = "') : -len(b'";')]
+        return xw_data.replace(b"\\", b"")


### PR DESCRIPTION
CrosswordCompiler (CC) games are (or contain) XML encoded puzzles. In some cases, as with Daily Pop, these puzzles are sent with headers that don't specify the character encoding. Nevertheless, the XML declaration in the file specifies it correctly - e.g.

    encoding="UTF-8"

When this happens, because XML has the mimetype text/xml, requests will (correctly according to the spec) assume the ISO-8859-1 encoding. If a different encoding is used for the file, this will result in mojibake.

The decoding step is actually unncessary with CC puzzles because they are passed to an XML parsing library (xmltodict, using expat) which is capable of parsing the encoding from the declaration, rather than relying on the HTTP header.

This commit removes the unnecessary decode step. Fixes #275.