### PR TITLE
der standard: allow dashes in amuselabs ids

### DIFF
--- a/src/xword_dl/downloader/derstandarddownloader.py
+++ b/src/xword_dl/downloader/derstandarddownloader.py
@@ -65,7 +65,7 @@ class DerStandardDownloader(AmuseLabsDownloader):
             # html embed content is encoded -> beautifulsoup parsing would not work
             query_id = list(
                 re.findall(
-                    r"(http)(s)*(:\/\/.*\.amuselabs\.com\/pmm\/crossword)(\?id\=)([0-9a-zA-Z]+)(&)amp;(set\=[^&]+)",
+                    r"(http)(s)*(:\/\/.*\.amuselabs\.com\/pmm\/crossword)(\?id\=)([0-9a-zA-Z\-]+)(&)amp;(set\=[^&]+)",
                     str(res.text),
                 )
             )


### PR DESCRIPTION
This fixes failing Der Standard downloads over the last few days but I can't help but feel like the better solution is to move this logic up a level, as discussed in #270 and others