### PR TITLE
refactor page parsing approach, moving more logic to plugins

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -65,7 +65,9 @@ class AmuseLabsDownloader(BaseDownloader):
             base_path = ""
             puzzle_id = ""
             puzzle_set = ""
-            base_path_regex_match = re.search(r"PM_BasePath\s*=\s*\"(.*)\"", page_source)
+            base_path_regex_match = re.search(
+                r"PM_BasePath\s*=\s*\"(.*)\"", page_source
+            )
             if base_path_regex_match:
                 base_path = base_path_regex_match.groups()[0]
             embed_div = soup.find("div", attrs={"class": "pm-embed-div"})

--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -57,6 +57,25 @@ class AmuseLabsDownloader(BaseDownloader):
             if "amuselabs.com" in parsed_url.netloc:
                 return embed_src
 
+        script_sources = [
+            str(s.get("src")) for s in soup.find_all("script") if isinstance(s, Tag)
+        ]
+
+        if any(s.endswith("puzzleme-embed.js") for s in script_sources):
+            base_path = ""
+            puzzle_id = ""
+            puzzle_set = ""
+            base_path_regex_match = re.search(r"PM_BasePath\s*=\s*\"(.*)\"", page_source)
+            if base_path_regex_match:
+                base_path = base_path_regex_match.groups()[0]
+            embed_div = soup.find("div", attrs={"class": "pm-embed-div"})
+            if isinstance(embed_div, Tag):
+                puzzle_id = embed_div.get("data-id")
+                puzzle_set = embed_div.get("data-set")
+
+            if base_path and puzzle_id and puzzle_set:
+                return f"{base_path}crossword?id={puzzle_id}&set={puzzle_set}"
+
         return None
 
     def find_latest(self) -> str:

--- a/src/xword_dl/downloader/basedownloader.py
+++ b/src/xword_dl/downloader/basedownloader.py
@@ -137,8 +137,8 @@ class BaseDownloader:
         raise NotImplementedError
 
     @classmethod
-    def matches_embed_url(cls, src: str) -> str | None:
-        """Returns a URL to a puzzle, given an embedded link this plugin can parse."""
+    def matches_embed_pattern(cls, url: str, page_source: str) -> str | None:
+        """Returns a URL to a puzzle this plugin can parse, given HTML page source."""
         raise NotImplementedError
 
     @classmethod

--- a/src/xword_dl/downloader/compilerdownloader.py
+++ b/src/xword_dl/downloader/compilerdownloader.py
@@ -83,16 +83,20 @@ class CrosswordCompilerJSEncodedDownloader(CrosswordCompilerDownloader):
         super().__init__(**kwargs)
 
     @classmethod
-    def matches_embed_url(cls, src):
-        res = requests.get(src)
-        if not res.ok:
+    def matches_embed_pattern(cls, url="", page_source=""):
+        if url and not page_source:
+            res = requests.get(url)
+            page_source = res.text
+
+        if not page_source:
             return None
-        soup = BeautifulSoup(res.text, "lxml")
+
+        soup = BeautifulSoup(page_source, "lxml")
 
         for script in [
             s for s in soup.find_all("script") if isinstance(s, Tag) and s.get("src")
         ]:
-            js_url = urllib.parse.urljoin(src, str(script.get("src")))
+            js_url = urllib.parse.urljoin(url, str(script.get("src")))
             res = requests.get(js_url, headers={"User-Agent": "xword-dl"})
             if res.text.startswith("var CrosswordPuzzleData"):
                 return js_url

--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -8,7 +8,6 @@ import urllib.parse
 
 import requests
 
-from bs4 import BeautifulSoup, Tag
 from puz import Puzzle
 
 from .downloader import get_plugins
@@ -79,39 +78,23 @@ def by_url(url: str, **kwargs) -> tuple[Puzzle, str]:
 
 
 def parse_for_embedded_puzzle(url: str, **kwargs):
-    supported_downloaders = get_supported_outlets(matches_embed_url=True)
+    supported_downloaders = get_supported_outlets(matches_embed_pattern=True)
 
     res = requests.get(url, headers={"User-Agent": "xword-dl"})
-    soup = BeautifulSoup(res.text, "lxml")
+    page_source = res.content
 
-    sources = [
-        urllib.parse.urljoin(
-            url,
-            str(iframe.get("data-crossword-url", ""))
-            or str(iframe.get("data-src", ""))
-            or str(iframe.get("src", "")),
-        )
-        for iframe in soup.find_all("iframe")
-        if isinstance(iframe, Tag)
-    ]
-
-    sources = [src for src in sources if src != "about:blank"]
-
-    sources.insert(0, url)
-
-    for src in sources:
-        for dlr in supported_downloaders:
-            puzzle_url = dlr.matches_embed_url(src)
-            # TODO: would it be better to just return a URL and have controller
-            # request this from the plugin via normal methods?
-            if puzzle_url is not None:
-                return (dlr(url=url, **kwargs), puzzle_url)
+    for dlr in supported_downloaders:
+        puzzle_url = dlr.matches_embed_pattern(url, page_source)
+        # TODO: would it be better to just return a URL and have controller
+        # request this from the plugin via normal methods?
+        if puzzle_url is not None:
+            return (dlr(url=url, **kwargs), puzzle_url)
 
     return None, None
 
 
 def get_supported_outlets(
-    command_only=False, matches_url=False, matches_embed_url=False
+    command_only=False, matches_url=False, matches_embed_pattern=False
 ):
     matched_plugins = []
 
@@ -125,9 +108,12 @@ def get_supported_outlets(
             is getattr(__bd.matches_url, "__func__")
         ):
             continue
-        if matches_embed_url and (
-            getattr(plugin.matches_embed_url, "__func__")
-            is getattr(__bd.matches_embed_url, "__func__")
+        if matches_embed_pattern and (
+            (
+                getattr(plugin.matches_embed_pattern, "__func__")
+                is getattr(__bd.matches_embed_pattern, "__func__")
+            )
+            or ("matches_embed_pattern" not in plugin.__dict__)
         ):
             continue
         matched_plugins.append(plugin)

--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -81,7 +81,7 @@ def parse_for_embedded_puzzle(url: str, **kwargs):
     supported_downloaders = get_supported_outlets(matches_embed_pattern=True)
 
     res = requests.get(url, headers={"User-Agent": "xword-dl"})
-    page_source = res.content
+    page_source = res.text
 
     for dlr in supported_downloaders:
         puzzle_url = dlr.matches_embed_pattern(url, page_source)


### PR DESCRIPTION
Previously, when `xword-dl` was invoked by URL, the `parse_for_embedded_puzzle` function would extract a bunch of candidate URLs that might be suitable puzzle URLs, and then those would be evaluated one-by-one by appropriate downloader classes.

In this new approach, `parse_for_embedded_puzzle` grabs the page source and passes _that_ to a matching function in the relevant downloaders. I think this is cleaner, and it also allows the analysis in each downloader to be a little more specific. That in turn should open the door to embeds that use some technique other than an iframe source: I'm thinking in particular about the AmuseLabs JS embeds (as with the DerStandardDownloader, currently) but it may also apply to upcoming Crosshare puzzles.

One gotcha while implementing this is that only downloaders that have implemented their own `matches_embed_pattern()` should be tested, so I added another check to the `get_plugins` conditional that checks for the `"matches_embed_pattern"` key in each downloader's `__dict__`. I feel like @afontenot might not like that so I'm curious for feedback! ~~If we don't mind it, I think we could actually replace the `get_attr` check from the opposite direction with it, because the function name will be in the `__dict__` if it's defined at that level, whether or not it is in a parent.~~ (this was wrong, see comment below)