### PR TITLE
amuselabs: allow for blank clues in parsing crossword data

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -253,7 +253,7 @@ class AmuseLabsDownloader(BaseDownloader):
             key=lambda word: (word["y"], word["x"], not word["acrossNotDown"]),
         )
 
-        clues = [word["clue"]["clue"] for word in weirdass_puz_clue_sorting]
+        clues = [word["clue"].get("clue", "") for word in weirdass_puz_clue_sorting]
 
         puzzle.clues.extend(clues)
 


### PR DESCRIPTION
AmuseLabs allows puzzles to have blank clues (for thematic reasons, I'd imagine) as seen in the LA Times puzzle from 9/18/25. This change preserves the non-clue instead of failing.

Fixes #283.