### PR TITLE
Remove McKinsey downloader, as it has stopped working due to anti-scraping techniques

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -82,15 +82,6 @@ jobs:
       - name: Test LA Times Mini by date
         if: '!cancelled()'
         run: xword-dl latm -d "july 20, 2025"
-      - name: Test McKinsey latest
-        if: '!cancelled()'
-        run: xword-dl mck
-      - name: Test McKinsey by date
-        if: '!cancelled()'
-        run: xword-dl mck -d "september 26, 2023"
-      - name: Test McKinsey by URL
-        if: '!cancelled()'
-        run: xword-dl "https://www.mckinsey.com/featured-insights/the-mckinsey-crossword/october-31-2023"
       - name: Test New York Times latest
         if: '!cancelled()'
         env:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Supported outlets:
 |*Guardian Weekend*|`grdw`|✔️||✔️|
 |*Los Angeles Times*|`lat`|✔️|✔️||
 |*Los Angeles Times Mini*|`latm`|✔️|✔️||
-|*The McKinsey Crossword*|`mck`|✔️|✔️|✔️|
 |*New York Times*|`nyt`|✔️|✔️|✔️|
 |*New York Times Mini*|`nytm`|✔️|✔️|✔️|
 |*New York Times Variety*|`nytv`||✔️||

--- a/src/xword_dl/downloader/mckinseydownloader.py
+++ b/src/xword_dl/downloader/mckinseydownloader.py
@@ -10,7 +10,11 @@ from ..util import XWordDLException
 
 
 class McKinseyDownloader(AmuseLabsDownloader):
-    command = "mck"
+    # command = "mck"
+    # Disabling as of 2025-09-27, because of anti-scraping tech used on McKinsey.com
+    # For posterity: they appear to be closing inbound requests by sniffing something
+    # on the SSL handshake to exclude non-browser user agents.
+    # Testing with curl showed results similar to https://github.com/curl/curl/issues/18608
     outlet = "The McKinsey Crossword"
     outlet_prefix = "McKinsey"
 
@@ -23,10 +27,11 @@ class McKinseyDownloader(AmuseLabsDownloader):
 
     @classmethod
     def matches_url(cls, url_components):
-        return (
-            "mckinsey.com" in url_components.netloc
-            and "/featured-insights/the-mckinsey-crossword" in url_components.path
-        )
+        # return (
+        #     "mckinsey.com" in url_components.netloc
+        #     and "/featured-insights/the-mckinsey-crossword" in url_components.path
+        # )
+        return False
 
     def find_by_date(self, dt):
         """


### PR DESCRIPTION
Alas, another one bites the dust. McKinsey is doing some browser fingerprinting that I can't figure out how to get around, so I've had to turn this one off.

Closes #274  