### PR TITLE
observer: fix typo in speedy url matching

### DIFF
--- a/src/xword_dl/downloader/observerdownloader.py
+++ b/src/xword_dl/downloader/observerdownloader.py
@@ -82,5 +82,5 @@ class SpeedyDownloader(ObserverDownloader):
     def matches_url(cls, url_components):
         return (
             "observer.co.uk" in url_components.netloc
-            and "/puzzles/everyman/article" in url_components.path
+            and "/puzzles/speedy/article" in url_components.path
         )


### PR DESCRIPTION
Silly copy and paste error, wasn't stopping downloads but was complicating metadata.