### PR TITLE
newsday: override publish timestamp with date derived from puzzle ID

### DIFF
--- a/src/xword_dl/downloader/newsdaydownloader.py
+++ b/src/xword_dl/downloader/newsdaydownloader.py
@@ -17,8 +17,11 @@ class NewsdayDownloader(AmuseLabsDownloader):
         )
 
     def guess_date_from_id(self, puzzle_id):
-        date_string = puzzle_id.split("_")[2]
-        self.date = datetime.datetime.strptime(date_string, "%Y%m%d")
+        try:
+            date_string = puzzle_id.split("_")[2]
+            self.date = datetime.datetime.strptime(date_string, "%Y%m%d")
+        except (IndexError, ValueError):
+            pass
 
     def find_by_date(self, dt):
         url_formatted_date = dt.strftime("%Y%m%d")
@@ -27,3 +30,8 @@ class NewsdayDownloader(AmuseLabsDownloader):
         self.get_and_add_picker_token()
 
         return self.find_puzzle_url_from_id(self.id)
+
+    def parse_xword(self, xw_data):
+        self.guess_date_from_id(self.id)
+
+        return super().parse_xword(xw_data)


### PR DESCRIPTION
Fixes #296 