### PR TITLE
BaseDownloader: Set default User-Agent string for downloaders if unset in settings

### DIFF
--- a/src/xword_dl/downloader/basedownloader.py
+++ b/src/xword_dl/downloader/basedownloader.py
@@ -9,6 +9,10 @@ from ..util import (
     remove_invalid_chars_from_filename,
     sanitize_for_puzfile,
 )
+try:
+    from .._version import __version__ as __version__  # type: ignore
+except ModuleNotFoundError:
+    __version__ = "0.0.0-dev"
 
 
 class BaseDownloader:
@@ -39,8 +43,12 @@ class BaseDownloader:
         if kwargs.get("filename"):
             self.settings["filename"] = kwargs.get("filename")
 
+        headers = self.settings.get("headers", {})
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = f"xword-dl/{__version__}"
+
         self.session = requests.Session()
-        self.session.headers.update(self.settings.get("headers", {}))
+        self.session.headers.update(headers)
         self.session.cookies.update(self.settings.get("cookies", {}))
 
     def pick_filename(self, puzzle: Puzzle, **kwargs) -> str:

--- a/src/xword_dl/downloader/basedownloader.py
+++ b/src/xword_dl/downloader/basedownloader.py
@@ -9,6 +9,7 @@ from ..util import (
     remove_invalid_chars_from_filename,
     sanitize_for_puzfile,
 )
+
 try:
     from .._version import __version__ as __version__  # type: ignore
 except ModuleNotFoundError:

--- a/src/xword_dl/downloader/newyorkerdownloader.py
+++ b/src/xword_dl/downloader/newyorkerdownloader.py
@@ -99,9 +99,7 @@ class NewYorkerDownloader(PuzzmoDownloader):
         return urllib.parse.urljoin(self.api_endpoint, puzzle_id)
 
     def fetch_data(self, solver_url):
-        res = self.session.get(
-            solver_url, headers={"User-Agent": "xword-dl"}
-        )  # TODO: a custom user-agent is necessary here, but we should honor a user-set one
+        res = self.session.get(solver_url)
         try:
             res.raise_for_status()
         except Exception as err:


### PR DESCRIPTION
Some outlets screen for the `requests` UA string and we'd been manually setting a User-Agent in those cases, but it should be something configurable at the settings level, and it's good hygiene to be sending a meaningful UA string wherever we can.