### PR TITLE
add Vulture, refactor default settings and Billboard downloader

### DIFF
--- a/src/xword_dl/downloader/basedownloader.py
+++ b/src/xword_dl/downloader/basedownloader.py
@@ -27,6 +27,8 @@ class BaseDownloader:
 
         self.settings = {}
 
+        self.settings["headers"] = {"User-Agent": f"xword-dl/{__version__}"}
+
         self.settings.update(read_config_values("general"))
 
         if "inherit_settings" in kwargs:
@@ -41,15 +43,8 @@ class BaseDownloader:
 
         self.settings.update(kwargs)
 
-        if kwargs.get("filename"):
-            self.settings["filename"] = kwargs.get("filename")
-
-        headers = self.settings.get("headers", {})
-        if "User-Agent" not in headers:
-            headers["User-Agent"] = f"xword-dl/{__version__}"
-
         self.session = requests.Session()
-        self.session.headers.update(headers)
+        self.session.headers.update(self.settings.get("headers", {}))
         self.session.cookies.update(self.settings.get("cookies", {}))
 
     def pick_filename(self, puzzle: Puzzle, **kwargs) -> str:

--- a/src/xword_dl/downloader/vulturedownloader.py
+++ b/src/xword_dl/downloader/vulturedownloader.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup, Tag
+
+from .amuselabsdownloader import AmuseLabsDownloader
+from ..util import XWordDLException
+
+
+class VultureDownloader(AmuseLabsDownloader):
+    command = "vult"
+    outlet = "Vulture"
+    outlet_prefix = "Vulture"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.archive_url = "https://www.vulture.com/tags/vulture-10x10/"
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return (
+            "vulture.com" in url_components.netloc
+            and "/article/daily-crossword-puzzle" in url_components.path
+        )
+
+    def find_latest(self) -> str:
+        res = self.session.get(self.archive_url)
+        if not res.ok:
+            raise XWordDLException(
+                f"Could not connect to Vulture index at {self.archive_url}"
+            )
+
+        soup = BeautifulSoup(res.text, features="lxml")
+
+        first_tile = soup.find("li", attrs={"class": "article"})
+
+        if not (isinstance(first_tile, Tag)):
+            raise XWordDLException("Unable to find latest Vulture puzzle")
+
+        link = first_tile.find("a")
+
+        if not (isinstance(link, Tag)):
+            raise XWordDLException("Puzzle link not found in expected place")
+
+        url = str(link.get("href"))
+
+        return url
+
+    def find_by_date(self, dt):
+        url_format = f"{dt:%B-{dt.day}-%Y}".lower()
+        guessed_url = (
+            f"https://www.vulture.com/article/daily-crossword-puzzle-{url_format}.html"
+        )
+        res = self.session.head(guessed_url)
+        if res.status_code == 404:
+            raise XWordDLException(
+                f"No page found for the specified date (tried {guessed_url})"
+            )
+
+        return guessed_url
+
+    def find_solver(self, url):
+        try:
+            parsed_url = urlparse(url)
+            slug = parsed_url.path.split("/")[-1].removesuffix(".html")
+            date_section = "-".join(slug.split("-")[-3:])
+            self.date = datetime.strptime(date_section, "%B-%d-%Y")
+        except Exception:
+            pass
+
+        res = self.session.get(url)
+        if not res.ok:
+            raise XWordDLException(f"Connection error: status code {res.status_code}")
+
+        solver_url = self.matches_embed_pattern(page_source=res.text)
+
+        if not solver_url:
+            raise XWordDLException("Can't find latest Vulture puzzle.")
+
+        return solver_url


### PR DESCRIPTION
A little bit of a grab bag here, but conceptually related: Writing the Vulture downloader required the standardized User-Agent work in #299 but suggested a cleaner way of implementing it, which I've now done. It also clarified some implementation issues in the recently introduced Billboard downloader from #298, which I've now fixed.