### PR TITLE
Add HTTPS_PROXY to the environment for New Yorker puzzle tests

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -123,26 +123,42 @@ jobs:
           xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "9/27/18"
       - name: Test New Yorker latest
         if: '!cancelled()'
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         run: xword-dl tny
       - name: Test New Yorker by date
         if: '!cancelled()'
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         run: xword-dl tny -d "3/31/23"
       - name: Test New Yorker by URL
         if: '!cancelled()'
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/01"
       - name: Test New Yorker themed
         if: '!cancelled()'
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/05"
       - name: Test New Yorker themed, special chars title
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         if: '!cancelled()'
         run: xword-dl tny -d 1/12/24
       - name: Test New Yorker Mini latest
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         if: '!cancelled()'
         run: xword-dl tnym
       - name: Test New Yorker Mini by date
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         if: '!cancelled()'
         run: xword-dl tnym -d "5/16/25"
       - name: Test New Yorker Mini by URL
+        env:
+          HTTPS_PROXY: ${{ secrets.XWORD_DL_HTTPS_PROXY }}
         if: '!cancelled()'
         run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/mini-crossword/2025/05/16"	
       - name: Test Newsday latest


### PR DESCRIPTION
This PR allows for the definition of an XWORD_DL_HTTPS_PROXY GitHub secret which, if set, will be used to override Python's network requests to go through the specified proxy.

It turns out The New Yorker API is hosted on an AWS network, and I think it's possible that whatever rules are causing the sporadic blocking of TNY requests from xword-dl will be circumvented when the originating IP address is in fact also in the AWS network.

I discovered that I could set up a very simple EC2 instance on the free tier, install "tinyproxy", and use it as an HTTPS proxy from the xword-dl automated tests. This causes the requests made by xword-dl running on GitHub's servers to appear to the New Yorker API as though they are coming from within AWS.

Since the proxy is only set for the New Yorker tests, I don't think the usage on the server would  ever likely exceed the amount allowed but the free tier. So, if you choose to adopt this approach:

1. Create an AWS account if needed.
2. Add an EC2 t3.micro instance running Ubuntu (free tier)
3. Configure the EC2 instance with a security group allowing ports 22 (ssh), 80 (http), and 8888 UDP (for the proxy)
4. ssh in to the new instance, and `apt-get install tinyproxy`
5. sudo edit the  /etc/tinyproxy/tinyproxy.conf file and add:

```
Listen 0.0.0.0
Allow 0.0.0.0/0
BasicAuth [username] [password]
```

6. sudo systemctl restart tinyproxy

Now you should be able to set a `XWORD_DL_HTTPS_PROXY` secret with a URL of the form:

```
http://[username]:[password]@[instance-ip]:8888
```

And the pertinent tests will be passed through the AWS proxy.
