### PR TITLE
add support for Vox (Amuse Labs compatible) download by date via calendar picker

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -25,6 +25,7 @@ class AmuseLabsDownloader(BaseDownloader):
 
         # these values must be overridden by subclasses, if used
         self.picker_url = None
+        self.calendar_url = None
         self.url_from_id = None
 
     @classmethod
@@ -109,6 +110,37 @@ class AmuseLabsDownloader(BaseDownloader):
         self.get_and_add_picker_token(res.text)
 
         return self.find_puzzle_url_from_id(self.id)
+
+    def find_by_date(self, dt: datetime) -> str:
+        if self.calendar_url is None:
+            raise XWordDLException(
+                "This outlet does not support finding crosswords by date"
+            )
+
+        res = requests.get(f"{self.calendar_url}&year={dt.year}&month={dt.month - 1}")
+        soup = BeautifulSoup(res.text, features="lxml")
+
+        # look for the calendar box for the requested day
+        puzzle_id = None
+        for div in soup.select(".crossword-calendar-box"):
+            date_divs = div.select(".date")
+            if date_divs == [] or date_divs[0].get_text() != str(dt.day):
+                continue
+
+            id_divs = div.select("[data-puzzle-type]")
+            if id_divs == []:
+                break
+
+            puzzle_id = id_divs[0].get("data-id")
+
+        if puzzle_id is None:
+            raise XWordDLException(
+                "No puzzle found for the requested date"
+            )
+
+        self.get_and_add_picker_token(res.text)
+
+        return self.find_puzzle_url_from_id(puzzle_id)
 
     @staticmethod
     def _select_puzzle_at_index_from_date_picker(picker_src=None, index=0):

--- a/src/xword_dl/downloader/voxdownloader.py
+++ b/src/xword_dl/downloader/voxdownloader.py
@@ -12,6 +12,7 @@ class VoxDownloader(AmuseLabsDownloader):
         super().__init__(**kwargs)
 
         self.picker_url = "https://cdn3.amuselabs.com/vox/date-picker?set=vox"
+        self.calendar_url = "https://cdn3.amuselabs.com/vox/calendar-picker?set=vox"
         self.url_from_id = (
             "https://cdn3.amuselabs.com/vox/crossword?id={puzzle_id}&set=vox"
         )


### PR DESCRIPTION
I spent some time poking around Vox's crossword archive and found that it references `/calendar-picker`, in a similar manner to the existing `/date-picker` resource used by other Amuse Labs puzzles. This resource doesn't provide JSON-formatted info like the other, but it does allow selecting a year/month via URL parameters, and provides a day->puzzle ID mapping after a bit of HTML parsing.

I've used this to implement `find_by_date` for `AmuseLabsDownloader`, and provided the required `calendar_url` for the Vox downloader. I haven't tested with other Amuse Labs puzzles, but I imagine that `calendar_url` shouldn't be too hard to find to enable this for others (maybe we should just use `picker_url` and replace `date-picker` with `calendar-picker`?

To test that this works:

```shell
xword-dl vox --date 2025-12-31
```

and that missing puzzles are also handled gracefully:

```shell
# others exist in the same month, but none for this day
xword-dl vox --date 2024-12-29

# none exist in this month at all
xword-dl vox --date 2002-01-01
```