### PR TITLE
Include New York Times Midi

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Supported outlets:
 |*Los Angeles Times Mini*|`latm`|✔️|✔️||
 |*New York Times*|`nyt`|✔️|✔️|✔️|
 |*New York Times Mini*|`nytm`|✔️|✔️|✔️|
+|*New York Times Midi*|`nytd`|✔️|✔️|✔️|
 |*New York Times Variety*|`nytv`||✔️||
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*The New Yorker Mini*|`tnym`|✔️|✔️|✔️|

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -229,6 +229,33 @@ class NewYorkTimesVarietyDownloader(NewYorkTimesDownloader):
             )
 
 
+class NewYorkTimesMidiDownloader(NewYorkTimesDownloader):
+    command = "nytd"
+    outlet = "New York Times Midi"
+    outlet_prefix = "NY Times Midi"
+
+    def __init__(self, **kwargs):
+        super().__init__(inherit_settings="nyt", **kwargs)
+
+        self.url_from_date = (
+            "https://www.nytimes.com/svc/crosswords/v6/puzzle/midi/{}.json"
+        )
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return "nytimes.com" in url_components.netloc and "midi" in url_components.path
+
+    def find_latest(self):
+        oracle = "https://www.nytimes.com/svc/crosswords/v2/oracle/midi.json"
+
+        res = requests.get(oracle)
+        puzzle_date = res.json()["results"]["current"]["print_date"]
+
+        url = self.url_from_date.format(puzzle_date)
+
+        return url
+
+
 class NewYorkTimesMiniDownloader(NewYorkTimesDownloader):
     command = "nytm"
     outlet = "New York Times Mini"


### PR DESCRIPTION
- Add downloader for the NYT Midi: https://www.nytimes.com/crosswords/archive/midi