### PR TITLE
Use session for HTTP requests in AMUniversal and USA Today downloaders

### DIFF
--- a/src/xword_dl/downloader/amuniversaldownloader.py
+++ b/src/xword_dl/downloader/amuniversaldownloader.py
@@ -39,7 +39,7 @@ class AMUniversalDownloader(BaseDownloader):
         attempts = 3
         while attempts:
             try:
-                res = requests.get(solver_url)
+                res = self.session.get(solver_url)
                 xword_data = res.json()
                 break
             except json.JSONDecodeError:
@@ -133,7 +133,7 @@ class USATodayDownloader(BaseDownloader):
         self.date = dt
         url = f"http://picayune.uclick.com/comics/usaon/data/usaon{dt:%y%m%d}-data.xml"
         try:
-            res = requests.head(url)
+            res = self.session.head(url)
             res.raise_for_status()
         except requests.HTTPError:
             raise XWordDLException("Unable to find puzzle for date provided.")
@@ -159,7 +159,7 @@ class USATodayDownloader(BaseDownloader):
         return url
 
     def fetch_data(self, solver_url):
-        res = requests.get(solver_url)
+        res = self.session.get(solver_url)
 
         xw_data = res.content.decode()
 


### PR DESCRIPTION
## Summary

- `AMUniversalDownloader.fetch_data()` uses bare `requests.get()` instead of `self.session.get()`, bypassing the session's configured User-Agent header
- The AMUniversal API (`gamedata.services.amuniversal.com`) returns **403** to the default `python-requests` User-Agent, making the Universal downloader fail
- Same issue in `USATodayDownloader.fetch_data()` and `USATodayDownloader.find_by_date()` (`requests.get()` and `requests.head()`)

Switching to `self.session` sends the `xword-dl/VERSION` User-Agent configured by `BaseDownloader`, which resolves the 403. This also brings these two downloaders in line with the pattern used by other downloaders (AmuseLabs, CrosswordCompiler, etc.) that already use `self.session`.

## Changes

Three one-line changes in `amuniversaldownloader.py`:

| Class | Method | Before | After |
|-------|--------|--------|-------|
| `AMUniversalDownloader` | `fetch_data` | `requests.get(solver_url)` | `self.session.get(solver_url)` |
| `USATodayDownloader` | `find_by_date` | `requests.head(url)` | `self.session.head(url)` |
| `USATodayDownloader` | `fetch_data` | `requests.get(solver_url)` | `self.session.get(solver_url)` |

## Test plan

- [x] Verified `xword-dl uni` successfully downloads Universal puzzle (previously returned 403)
- [x] Verified `xword-dl usa` still works correctly
- [x] Confirmed `requests` import is still needed (`requests.HTTPError` reference on line 138)