### PR TITLE
add downloader for nyt monthly bonus puzzle series

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -128,6 +128,24 @@ jobs:
           NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
         run: |
           xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "9/27/18"
+      - name: Test New York Times mini latest
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nytm --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+      - name: Test New York Times midi latest
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nytd --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+      - name: Test New York Times bonus latest
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nytb --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
       - name: Test New Yorker latest
         if: '!cancelled()'
         run: xword-dl tny

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -311,13 +311,16 @@ class NewYorkTimesBonusDownloader(NewYorkTimesDownloader):
     def find_latest(self):
         today = datetime.date.today()
         q = "https://www.nytimes.com/svc/crosswords/v3/null/puzzles.json"
-        res = requests.get(q, params={
-            "publish_type": "bonus",
-            "sort_order": "desc",
-            "sort_by": "print_date",
-            "date_start": f"{today.year}-01-01",
-            "date_end": f"{today.year}-12-31",
-        })
+        res = requests.get(
+            q,
+            params={
+                "publish_type": "bonus",
+                "sort_order": "desc",
+                "sort_by": "print_date",
+                "date_start": f"{today.year}-01-01",
+                "date_end": f"{today.year}-12-31",
+            },
+        )
         res.raise_for_status()
 
         results = res.json().get("results", [])

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -290,3 +290,30 @@ class NewYorkTimesMiniDownloader(NewYorkTimesDownloader):
         url = self.url_from_date.format(puzzle_date)
 
         return url
+
+
+class NewYorkTimesMidiDownloader(NewYorkTimesDownloader):
+    command = "nytmid"
+    outlet = "New York Times Midi"
+    outlet_prefix = "NY Times Midi"
+
+    def __init__(self, **kwargs):
+        super().__init__(inherit_settings="nyt", **kwargs)
+
+        self.url_from_date = (
+            "https://www.nytimes.com/svc/crosswords/v6/puzzle/midi/{}.json"
+        )
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return "nytimes.com" in url_components.netloc and "midi" in url_components.path
+
+    def find_latest(self):
+        oracle = "https://www.nytimes.com/svc/crosswords/v2/oracle/midi.json"
+
+        res = requests.get(oracle)
+        puzzle_date = res.json()["results"]["current"]["print_date"]
+
+        url = self.url_from_date.format(puzzle_date)
+
+        return url

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -317,3 +317,41 @@ class NewYorkTimesMidiDownloader(NewYorkTimesDownloader):
         url = self.url_from_date.format(puzzle_date)
 
         return url
+
+
+class NewYorkTimesBonusDownloader(NewYorkTimesDownloader):
+    command = "nytbonus"
+    outlet = "New York Times Bonus"
+    outlet_prefix = "NY Times Bonus"
+
+    def __init__(self, **kwargs):
+        super().__init__(inherit_settings="nyt", **kwargs)
+
+        self.url_from_date = (
+            "https://www.nytimes.com/svc/crosswords/v6/puzzle/bonus/{}.json"
+        )
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return "nytimes.com" in url_components.netloc and "bonus" in url_components.path
+
+    def find_latest(self):
+        today = datetime.date.today()
+        q = "https://www.nytimes.com/svc/crosswords/v3/null/puzzles.json"
+        res = requests.get(q, params={
+            "publish_type": "bonus",
+            "sort_order": "desc",
+            "sort_by": "print_date",
+            "date_start": f"{today.year}-01-01",
+            "date_end": f"{today.year}-12-31",
+        })
+        res.raise_for_status()
+
+        results = res.json().get("results", [])
+
+        if not results:
+            raise XWordDLException("No bonus puzzles found for this year.")
+
+        puzzle_date = results[0]["print_date"]
+
+        return self.url_from_date.format(puzzle_date)

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -292,35 +292,8 @@ class NewYorkTimesMiniDownloader(NewYorkTimesDownloader):
         return url
 
 
-class NewYorkTimesMidiDownloader(NewYorkTimesDownloader):
-    command = "nytmid"
-    outlet = "New York Times Midi"
-    outlet_prefix = "NY Times Midi"
-
-    def __init__(self, **kwargs):
-        super().__init__(inherit_settings="nyt", **kwargs)
-
-        self.url_from_date = (
-            "https://www.nytimes.com/svc/crosswords/v6/puzzle/midi/{}.json"
-        )
-
-    @classmethod
-    def matches_url(cls, url_components):
-        return "nytimes.com" in url_components.netloc and "midi" in url_components.path
-
-    def find_latest(self):
-        oracle = "https://www.nytimes.com/svc/crosswords/v2/oracle/midi.json"
-
-        res = requests.get(oracle)
-        puzzle_date = res.json()["results"]["current"]["print_date"]
-
-        url = self.url_from_date.format(puzzle_date)
-
-        return url
-
-
 class NewYorkTimesBonusDownloader(NewYorkTimesDownloader):
-    command = "nytbonus"
+    command = "nytb"
     outlet = "New York Times Bonus"
     outlet_prefix = "NY Times Bonus"
 


### PR DESCRIPTION
Downloader for the new york times "bonus" puzzle series (a regular monthly feature since Feb 1997). Named `nytb` to follow short-form convention for NYT:
 - `nyt`: daily
 - `nytm`: mini
 - `nytd`: midi
 - `nytb`: bonus

Also, while I was there, added all the 3 new ones to the nightly download job for testing purposes.