### PR TITLE
wapo: reject non-Sunday dates and surface empty responses as "no puzzle"

### DIFF
--- a/src/xword_dl/downloader/wapodownloader.py
+++ b/src/xword_dl/downloader/wapodownloader.py
@@ -23,6 +23,17 @@ class WaPoDownloader(BaseDownloader):
         return self.find_by_date(most_recent_sunday)
 
     def find_by_date(self, dt):
+        # The Washington Post only publishes a Sunday crossword (by Evan
+        # Birnholz) — the API endpoint has no puzzles for other days of the
+        # week, so reject non-Sunday dates up front with a clear error.
+        # isoweekday(): Monday=1 ... Sunday=7.
+        if dt.isoweekday() != 7:
+            raise XWordDLException(
+                f"Invalid date: The Washington Post only publishes a Sunday "
+                f"crossword (no puzzle for {dt.strftime('%Y-%m-%d')}, which is "
+                f"a {dt.strftime('%A')})."
+            )
+
         self.date = dt
         url_formatted_date = dt.strftime("%Y/%m/%d")
 
@@ -38,6 +49,15 @@ class WaPoDownloader(BaseDownloader):
             res.raise_for_status()
         except Exception as err:
             raise XWordDLException("Error downloading puzzle:", err)
+
+        # The WaPo API returns HTTP 200 with an empty body when no puzzle
+        # exists for the requested date (e.g. Sundays before ~May 2025).
+        # Surface this as a clear "no puzzle" error rather than the more
+        # cryptic "No parseable JSON".
+        if not res.text.strip():
+            raise XWordDLException(
+                f"No Washington Post puzzle available at {solver_url}."
+            )
 
         try:
             xw_data = res.json()


### PR DESCRIPTION
Fixes #321.

## What's wrong

The Washington Post only publishes a Sunday crossword (Evan Birnholz's weekly), and the games-service endpoint has no puzzles for other days of the week. The downloader previously sent every date to the same `/crossword/levels/sunday/YYYY/MM/DD` URL, and the API responded with HTTP 200 and an empty body. That failed `res.json()` and surfaced as the cryptic `No parseable JSON at <url>` — both for non-Sunday dates and for Sundays before ~May 2025 that the API doesn't have.

## What this PR does

Two small fixes in `wapodownloader.py`:

1. **`find_by_date`** now rejects non-Sunday dates up front with a message that names the day of the week. Mirrors the existing TGAM pattern at [`globeandmaildownloader.py:58`](https://github.com/thisisparker/xword-dl/blob/main/src/xword_dl/downloader/globeandmaildownloader.py#L58) which refuses Sundays for the same reason. This fails fast without a network round-trip.
2. **`fetch_data`** now detects an empty response body and raises `"No Washington Post puzzle available at <url>"` instead of `"No parseable JSON"`. This makes the old-Sunday case actionable without misleading anyone into thinking the API format changed.

`find_latest` is untouched — it already computes the most recent Sunday and remains the correct entry point.

## Verification

Tested against the live endpoint (xword-dl 2025.10.14 + this patch):

| Command | Before | After |
|---|---|---|
| `wp -d 2026-04-20` (Mon) | `No parseable JSON at .../sunday/2026/04/20` | `Invalid date: The Washington Post only publishes a Sunday crossword (no puzzle for 2026-04-20, which is a Monday).` (no network call) |
| `wp -d 2026-04-19` (Sun) | downloads | downloads ("The Crowd Goes Wild" by Evan Birnholz, 5086 bytes) |
| `wp -d 2024-01-07` (old Sun) | `No parseable JSON at .../sunday/2024/01/07` | `No Washington Post puzzle available at .../sunday/2024/01/07.` |
| `wp -l` | works | works (unchanged; resolves to most recent Sunday) |

No test harness exists in this repo, so verification was by live invocation.