### PR TITLE
Set diagramless flag in .puz file when downloading diagramless puzzle

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -115,6 +115,13 @@ jobs:
           NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
         run: |
           xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/17/23"
+      - name: Test New York Times Variety (diagramless) by date
+        if: '!cancelled()'
+        env:
+          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+        run: |
+          xword-dl nytv --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/14/08" -o diagramless.puz
+          xxd -s 48 -l 2 diagramless.puz | grep -q "0104"  # check diagramless flag is set
       - name: Test New York Times blank clues
         if: '!cancelled()'
         env:
@@ -144,7 +151,7 @@ jobs:
         run: xword-dl tnym -d "5/16/25"
       - name: Test New Yorker Mini by URL
         if: '!cancelled()'
-        run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/mini-crossword/2025/05/16"	
+        run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/mini-crossword/2025/05/16"
       - name: Test Newsday latest
         if: '!cancelled()'
         run: xword-dl nd

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -220,13 +220,22 @@ class NewYorkTimesVarietyDownloader(NewYorkTimesDownloader):
             "https://www.nytimes.com/svc/crosswords/v6/puzzle/variety/{}.json"
         )
 
+    def find_latest(self):
+        raise XWordDLException(
+            "NYT Variety puzzles are no longer published digitally. "
+            "Use --date to download a specific historical puzzle."
+        )
+
     def parse_xword(self, xw_data):
         try:
-            return super().parse_xword(xw_data)
+            puzzle = super().parse_xword(xw_data)
         except ValueError:
             raise XWordDLException(
                 "Encountered error while parsing data. Maybe the selected puzzle is not a crossword?"
             )
+        if xw_data.get("subcategory") == 3:
+            puzzle.puzzletype = 0x0401  # PuzzleType.Diagramless
+        return puzzle
 
 
 class NewYorkTimesMiniDownloader(NewYorkTimesDownloader):


### PR DESCRIPTION
Fix for Diagramless NYT Variety puzzles lose diagramless flag in generated .puz #317 

The downloader needs to check some metadata in the json blob. specifically `"subcategory" == 3`.  This was found by sampling. Diagramless puzzles have  this set; others don't.

Since `nytv` wasn't being tested it in the nightly, I added it as a test, and made it download a diagramless puzzle and just as simply as possible check that the correct bit is flipped. This seemed lighterweight than using `puz.py`, though I could do that if preferred. It also seemed better than not having a test.

Also, while I was at it, I figured I should override `find_latest` and raise an error, since nyt variety puzzles are no longer published online so `find_latest` no longer makes sense.
