### PR TITLE
amuselabs: fix session sharing and compute fvlt token

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -180,6 +180,7 @@ class AmuseLabsDownloader(BaseDownloader):
         )
         uid = self.session.cookies.get("uid")
         if set_name and self.id and uid:
+            assert self.url_from_id is not None
             self.url_from_id += "&fvlt=" + _compute_fvlt(set_name, self.id, uid)
 
     def find_puzzle_url_from_id(self, puzzle_id):

--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -356,7 +356,9 @@ def _compute_fvlt(set_name: str, puzzle_id: str, uid: str) -> str:
             t = (t + ord(c)) & 0xFFFFFFFF
         return t
 
-    return format((charsum(set_name) ^ charsum(puzzle_id) ^ charsum(uid)) & 0xFFFFFFFF, "x")
+    return format(
+        (charsum(set_name) ^ charsum(puzzle_id) ^ charsum(uid)) & 0xFFFFFFFF, "x"
+    )
 
 
 # helper functions for rawc deobfuscation

--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -100,7 +100,7 @@ class AmuseLabsDownloader(BaseDownloader):
                 "This outlet does not support finding the latest crossword."
             )
 
-        res = requests.get(self.picker_url)
+        res = self.session.get(self.picker_url)
 
         self.id = self._select_puzzle_at_index_from_date_picker(
             picker_src=res.text, index=0
@@ -144,7 +144,7 @@ class AmuseLabsDownloader(BaseDownloader):
                 "No picker URL was available. Please report this as a bug."
             )
         if not picker_source:
-            res = requests.get(self.picker_url)
+            res = self.session.get(self.picker_url)
             picker_source = res.text
 
         if "pickerParams.rawsps" in picker_source:
@@ -170,6 +170,17 @@ class AmuseLabsDownloader(BaseDownloader):
             token = picker_params.get("loadToken", None)
             if token:
                 self.url_from_id += "&loadToken=" + token
+
+        set_name = (
+            urllib.parse.parse_qs(urllib.parse.urlparse(self.picker_url).query).get(
+                "set", [None]
+            )[0]
+            if self.picker_url
+            else None
+        )
+        uid = self.session.cookies.get("uid")
+        if set_name and self.id and uid:
+            self.url_from_id += "&fvlt=" + _compute_fvlt(set_name, self.id, uid)
 
     def find_puzzle_url_from_id(self, puzzle_id):
         if self.url_from_id is None:
@@ -329,6 +340,23 @@ class AmuseLabsDownloader(BaseDownloader):
         if not self.date and self.id:
             self.guess_date_from_id(self.id)
         return super().pick_filename(puzzle, **kwargs)
+
+
+def _compute_fvlt(set_name: str, puzzle_id: str, uid: str) -> str:
+    """Compute the fvlt (first-visit load token) required by the AmuseLabs puzzle viewer.
+
+    Reverse-engineered from picker-min.js. The token is an XOR of unsigned
+    32-bit char-sum hashes of the set name, puzzle ID, and session UID cookie,
+    formatted as a lowercase hex string.
+    """
+
+    def charsum(s: str) -> int:
+        t = 0
+        for c in s:
+            t = (t + ord(c)) & 0xFFFFFFFF
+        return t
+
+    return format((charsum(set_name) ^ charsum(puzzle_id) ^ charsum(uid)) & 0xFFFFFFFF, "x")
 
 
 # helper functions for rawc deobfuscation


### PR DESCRIPTION
Two related fixes for AmuseLabs web-viewer downloaders (lat, nd, atl, vox, etc.):

1. find_latest() and get_and_add_picker_token() were using bare requests.get() for picker requests while fetch_data() uses self.session, so the uid cookie from the picker wasn't shared with the puzzle fetch.

2. AmuseLabs now requires an fvlt (first-visit load token) parameter on puzzle requests. Reverse-engineered from picker-min.js: it's an XOR of unsigned 32-bit char-sum hashes of the set name, puzzle ID, and uid session cookie. Computed in _compute_fvlt() and appended to the puzzle URL alongside the loadToken.