### PR TITLE
add downloader for Daily Princetonian puzzles

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -151,6 +151,15 @@ jobs:
       - name: Test Newsday by date
         if: '!cancelled()'
         run: xword-dl nd -d "dec. 12, 2023"
+      - name: Test Princetonian latest
+        if: '!cancelled()'
+        run: xword-dl prince
+      - name: Test Princetonian by date
+        if: '!cancelled()'
+        run: xword-dl prince -d "2026-03-30"
+      - name: Test Princetonian Mini latest
+        if: '!cancelled()'
+        run: xword-dl prince-mini
       - name: Test Observer Everyman latest
         if: '!cancelled()'
         run: xword-dl ever

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Supported outlets:
 |*Newsday*|`nd`|✔️|✔️||
 |*Observer Everyman*|`ever`|✔️||✔️|
 |*Observer Speedy*|`spdy`|✔️||✔️|
+|*Daily Princetonian*|`prince`|✔️|✔️||
+|*Daily Princetonian Mini*|`prince-mini`|✔️|✔️||
 |*Puzzmo*|`pzm`|✔️|✔️|✔️|
 |*Puzzmo Big*|`pzmb`|✔️|✔️|✔️|
 |*Simply Daily Puzzles*|`sdp`|✔️|✔️|✔️|

--- a/src/xword_dl/downloader/princetoniandownloader.py
+++ b/src/xword_dl/downloader/princetoniandownloader.py
@@ -46,9 +46,7 @@ class PrincetonianBaseDownloader(BaseDownloader):
     def fetch_data(self, solver_url):
         puzzle_id = solver_url.rstrip("/").split("/")[-1]
 
-        meta = self.session.get(
-            f"{self.BASE_URL}/api/crosswords/{puzzle_id}"
-        ).json()
+        meta = self.session.get(f"{self.BASE_URL}/api/crosswords/{puzzle_id}").json()
         clues = self.session.get(
             f"{self.BASE_URL}/api/crosswords/{puzzle_id}/clues"
         ).json()
@@ -115,9 +113,7 @@ class PrincetonianBaseDownloader(BaseDownloader):
             puzzle._extensions_order.append(b"GEXT")
             puzzle.markup()
 
-        sorted_clues = sorted(
-            clues, key=lambda c: (c["y"], c["x"], not c["is_across"])
-        )
+        sorted_clues = sorted(clues, key=lambda c: (c["y"], c["x"], not c["is_across"]))
         puzzle.clues = [c["clue"] for c in sorted_clues]
 
         return puzzle

--- a/src/xword_dl/downloader/princetoniandownloader.py
+++ b/src/xword_dl/downloader/princetoniandownloader.py
@@ -1,0 +1,157 @@
+import datetime
+
+import puz
+
+from .basedownloader import BaseDownloader
+from ..util import XWordDLException
+
+
+class PrincetonianBaseDownloader(BaseDownloader):
+    BASE_URL = "https://crossword.dailyprincetonian.com"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._mini = False
+
+    def _list_url(self):
+        return f"{self.BASE_URL}/api/crosswords?mini={str(self._mini).lower()}"
+
+    def _get_puzzle_list(self):
+        res = self.session.get(self._list_url())
+        res.raise_for_status()
+        return res.json()
+
+    def find_latest(self):
+        puzzles = self._get_puzzle_list()
+        if not puzzles:
+            raise XWordDLException("No puzzles found.")
+        latest = puzzles[0]
+        self.date = datetime.date.fromisoformat(latest["date"][:10])
+        return f"{self.BASE_URL}/api/crosswords/{latest['id']}"
+
+    def find_by_date(self, dt):
+        puzzles = self._get_puzzle_list()
+        target = dt.strftime("%Y-%m-%d")
+        for puzzle in puzzles:
+            if puzzle["date"].startswith(target):
+                self.date = dt
+                return f"{self.BASE_URL}/api/crosswords/{puzzle['id']}"
+        raise XWordDLException(f"No puzzle found for {target}.")
+
+    def find_solver(self, url):
+        if "api/crosswords" not in url:
+            return self.find_latest()
+        return url
+
+    def fetch_data(self, solver_url):
+        puzzle_id = solver_url.rstrip("/").split("/")[-1]
+
+        meta = self.session.get(
+            f"{self.BASE_URL}/api/crosswords/{puzzle_id}"
+        ).json()
+        clues = self.session.get(
+            f"{self.BASE_URL}/api/crosswords/{puzzle_id}/clues"
+        ).json()
+        authors = self.session.get(
+            f"{self.BASE_URL}/api/crosswords/{puzzle_id}/authors"
+        ).json()
+
+        return {"meta": meta, "clues": clues, "authors": authors}
+
+    def parse_xword(self, xw_data):
+        meta = xw_data["meta"]
+        clues = xw_data["clues"]
+        authors = xw_data["authors"]
+
+        puzzle = puz.Puzzle()
+        puzzle.title = meta.get("title", "")
+        puzzle.author = " / ".join(
+            f"{a['first_name']} {a['last_name']}".strip() for a in authors
+        )
+        puzzle.copyright = "The Daily Princetonian"
+
+        date_str = meta.get("date", "")
+        if date_str and not self.date:
+            self.date = datetime.date.fromisoformat(date_str[:10])
+
+        width = 0
+        height = 0
+        for c in clues:
+            if c["is_across"]:
+                width = max(width, c["x"] + len(c["answer"]))
+                height = max(height, c["y"] + 1)
+            else:
+                width = max(width, c["x"] + 1)
+                height = max(height, c["y"] + len(c["answer"]))
+
+        puzzle.width = width
+        puzzle.height = height
+
+        grid = [["." for _ in range(width)] for _ in range(height)]
+        circled = set()
+        for c in clues:
+            x, y, ans = c["x"], c["y"], c["answer"]
+            if c["is_across"]:
+                for i, letter in enumerate(ans):
+                    if letter.islower():
+                        circled.add((x + i, y))
+                    grid[y][x + i] = letter.upper()
+            else:
+                for i, letter in enumerate(ans):
+                    if letter.islower():
+                        circled.add((x, y + i))
+                    grid[y + i][x] = letter.upper()
+
+        puzzle.solution = "".join("".join(row) for row in grid)
+        puzzle.fill = "".join("-" if c != "." else "." for c in puzzle.solution)
+
+        if circled:
+            markup = bytes(
+                0x80 if (col, row) in circled else 0x00
+                for row in range(height)
+                for col in range(width)
+            )
+            puzzle.extensions[b"GEXT"] = markup
+            puzzle._extensions_order.append(b"GEXT")
+            puzzle.markup()
+
+        sorted_clues = sorted(
+            clues, key=lambda c: (c["y"], c["x"], not c["is_across"])
+        )
+        puzzle.clues = [c["clue"] for c in sorted_clues]
+
+        return puzzle
+
+
+class PrincetonianDownloader(PrincetonianBaseDownloader):
+    command = "prince"
+    outlet = "Daily Princetonian"
+    outlet_prefix = "Princetonian"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._mini = False
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return (
+            "crossword.dailyprincetonian.com" in url_components.netloc
+            and "minis" not in url_components.path
+        )
+
+
+class PrincetonianMiniDownloader(PrincetonianBaseDownloader):
+    command = "prince-mini"
+    outlet = "Daily Princetonian Mini"
+    outlet_prefix = "Princetonian Mini"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._mini = True
+
+    @classmethod
+    def matches_url(cls, url_components):
+        return (
+            "crossword.dailyprincetonian.com" in url_components.netloc
+            and "minis" in url_components.path
+        )


### PR DESCRIPTION
Fixes issue #312 .  

LLM disclosure: I let claude code do the reverse engineering and coding, but the code is reviewed and tested by me. 

New pieces:
- PrincetonianBaseDownloader(BaseDownloader): share implementation for daily puzzle and mini.  Princetonian exposes puzzle data via what looks to be a bespoke json api. this base class handles fetching and processing the data for both puzzle types.  Listing past puzzles requires passing a URL parameter ?mini=true|false; otherwise the two implementations are the same.
- PrincetonianDownloader(PrincetonianBaseDownloader): the daily puzzle
- PrincetonianMiniDownloader(PrincetonianBaseDownloader): the mini

I went back a ways through the archive to see if I could find any rebuses or other "special" content; the only thing I found was some circles (on [2026-02-17](https://crossword.dailyprincetonian.com/f9d32130-4026-4eab-a59e-d71a2fd12003)). These are implemented in the downloader. (json API represents them similarly to how [XD ](https://github.com/century-arcade/xd/blob/master/doc/xd-format.md)does-- lower case letters in the solution).

I didn't spend too much time thinking about short names for the downloaders. If it's important that these be 3-5 characters I can try to think of something, but as we get more and more -minis, -midis, and so on I suspect it's going to be harder and harder to abbreviate.

Testing: 
- I did some manual testing for both puzzle types; today vs previous dates.
- Added both to the nightly test job

Also added both to the table in the  README

