### PR TITLE
fix usability of not implemented errors

### DIFF
--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -37,14 +37,15 @@ def by_keyword(keyword: str, **kwargs) -> tuple[Puzzle, str]:
 
     if not date:
         puzzle_url = dl.find_latest()
-    elif date and hasattr(dl, "find_by_date"):
+    else:
         parsed_date = parse_date_or_exit(date)
         dl.date = parsed_date
-        puzzle_url = dl.find_by_date(parsed_date)
-    else:
-        raise XWordDLException(
-            "Selection by date not available for {}.".format(dl.outlet)
-        )
+        try:
+            puzzle_url = dl.find_by_date(parsed_date)
+        except NotImplementedError:
+            raise XWordDLException(
+                "Selection by date not available for {}.".format(dl.outlet)
+            )
 
     puzzle = dl.download(puzzle_url)
     filename = dl.pick_filename(puzzle)
@@ -243,10 +244,10 @@ def main():
         if selected_downloader is None:
             raise XWordDLException("Keyword {} not recognized.".format(args.source))
 
-        if not hasattr(selected_downloader, "authenticate"):
+        try:
+            selected_downloader.authenticate(args.username, args.password)
+        except NotImplementedError:
             sys.exit("This outlet does not support authentication.")
-
-        selected_downloader.authenticate(args.username, args.password)
 
     elif args.authenticate:
         sys.exit("Authentication flag must use a puzzle outlet keyword.")

--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -247,7 +247,7 @@ def main():
         try:
             selected_downloader.authenticate(args.username, args.password)
         except NotImplementedError:
-            sys.exit("This outlet does not support authentication.")
+            sys.exit("Authentication not supported for {}.".format(selected_downloader.outlet))
 
     elif args.authenticate:
         sys.exit("Authentication flag must use a puzzle outlet keyword.")

--- a/src/xword_dl/xword_dl.py
+++ b/src/xword_dl/xword_dl.py
@@ -247,7 +247,11 @@ def main():
         try:
             selected_downloader.authenticate(args.username, args.password)
         except NotImplementedError:
-            sys.exit("Authentication not supported for {}.".format(selected_downloader.outlet))
+            sys.exit(
+                "Authentication not supported for {}.".format(
+                    selected_downloader.outlet
+                )
+            )
 
     elif args.authenticate:
         sys.exit("Authentication flag must use a puzzle outlet keyword.")


### PR DESCRIPTION
Currently attempting to do something not implemented by a downloader gives an ugly traceback:

```console
$ xword-dl bill -d 12/31/24
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\adeja\Projects\xword-dl\.venv\Scripts\xword-dl.exe\__main__.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\adeja\Projects\xword-dl\src\xword_dl\xword_dl.py", line 280, in main
    puzzle, filename = by_keyword(args.source, **options)
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\adeja\Projects\xword-dl\src\xword_dl\xword_dl.py", line 43, in by_keyword
    puzzle_url = dl.find_by_date(parsed_date)
  File "C:\Users\adeja\Projects\xword-dl\src\xword_dl\downloader\basedownloader.py", line 136, in find_by_date
    raise NotImplementedError("Downloader does not support selection by date.")
```

```console
$ xword-dl db -a
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\adeja\Projects\xword-dl\.venv\Scripts\xword-dl.exe\__main__.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\adeja\Projects\xword-dl\src\xword_dl\xword_dl.py", line 250, in main
    selected_downloader.authenticate(args.username, args.password)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\adeja\Projects\xword-dl\src\xword_dl\downloader\basedownloader.py", line 155, in authenticate
    raise NotImplementedError
NotImplementedError
```

The code is actually trying to handle this case but it uses `hasattr` to test for the implementation of the required methods. This doesn't work because those methods do exist on the instance, as they're defined on its base class. Another approach: handle `NotImplementedError`, which is thrown by the default base class implementation of each downloader method.

I also updated the authentication error message to match the date selection message.

Result:

```console
$  xword-dl bill -d 12/31/24
Selection by date not available for Billboard.
```

```console
$ xword-dl db -a
Authentication not supported for Daily Beast.
```