### PR TITLE
fix for sdpc downloader

### DIFF
--- a/src/xword_dl/downloader/compilerdownloader.py
+++ b/src/xword_dl/downloader/compilerdownloader.py
@@ -103,5 +103,11 @@ class CrosswordCompilerJSEncodedDownloader(CrosswordCompilerDownloader):
 
     def fetch_data(self, solver_url):
         xw_data = super().fetch_data(solver_url)
-        xw_data = xw_data[len(b'var CrosswordPuzzleData = "') : -len(b'";')]
+        prefix = b'var CrosswordPuzzleData = "'
+        if not xw_data.startswith(prefix):
+            raise ValueError(
+                f"Unexpected response from {solver_url} — "
+                "puzzle data may have moved or the URL format may have changed."
+            )
+        xw_data = xw_data[len(prefix) : -len(b'";')]
         return xw_data.replace(b"\\", b"")

--- a/src/xword_dl/downloader/simplydailydownloader.py
+++ b/src/xword_dl/downloader/simplydailydownloader.py
@@ -61,7 +61,7 @@ class SimplyDailyCrypticDownloader(SimplyDailyDownloader):
     command = "sdpc"
     outlet = "Simply Daily Puzzles Cryptic"
     outlet_prefix = "Simply Daily Cryptic"
-    url_subdir = "daily-cryptic"
+    url_subdir = "daily-cryptic-crossword"
     qs_prefix = "dc1"
 
 


### PR DESCRIPTION
I noticed `sdpc` was failing in the validation job:

```console
$ xword-dl sdpc
Traceback (most recent call last):
  File "/home/runner/.local/bin/xword-dl", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.local/share/uv/tools/xword-dl/lib/python3.12/site-packages/xword_dl/xword_dl.py", line 285, in main
    puzzle, filename = by_keyword(args.source, **options)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/uv/tools/xword-dl/lib/python3.12/site-packages/xword_dl/xword_dl.py", line 50, in by_keyword
    puzzle = dl.download(puzzle_url)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/uv/tools/xword-dl/lib/python3.12/site-packages/xword_dl/downloader/basedownloader.py", line 91, in download
    puzzle = self.parse_xword(xword_data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/uv/tools/xword-dl/lib/python3.12/site-packages/xword_dl/downloader/compilerdownloader.py", line 26, in parse_xword
    xw = xmltodict.parse(xw_data)
         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/uv/tools/xword-dl/lib/python3.12/site-packages/xmltodict.py", line 359, in parse
    parser.Parse(xml_input, True)
xml.parsers.expat.ExpatError: syntax error: line 1, column 0
```

Fix was fairly simple, apparently the URL moved.  Since it took a while to debug I also upgraded the error message so if the expected text isn't present it raises a more helpful error.

