### PR TITLE
fix billboard daily download

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -126,17 +126,27 @@ class AmuseLabsDownloader(BaseDownloader):
 
         puzzles = param_obj.get("streakInfo", [])
 
-        if not puzzles:
-            raise XWordDLException("Unable to find puzzles data from picker page.")
+        if puzzles:
+            selected_id = puzzles[index].get("puzzleDetails", []).get("puzzleId")
 
-        selected_id = puzzles[index].get("puzzleDetails", []).get("puzzleId")
+            if not selected_id:
+                raise XWordDLException(
+                    "Unexpected puzzle metadata format. Please report this as a bug."
+                )
 
-        if not selected_id:
-            raise XWordDLException(
-                "Unexpected puzzle metadata format. Please report this as a bug."
-            )
+            return selected_id
 
-        return selected_id
+        rawsps = param_obj.get("rawsps", "")
+        if rawsps:
+            try:
+                sps = json.loads(base64.b64decode(rawsps + "==").decode("utf-8"))
+                puzzle_id = sps.get("id")
+                if puzzle_id:
+                    return puzzle_id
+            except (ValueError, KeyError):
+                pass
+
+        raise XWordDLException("Unable to find puzzles data from picker page.")
 
     def get_and_add_picker_token(self, picker_source=None):
         if self.picker_url is None:


### PR DESCRIPTION
Billboard daily download is failing:
```console
$ xword-dl bill
Unable to find puzzles data from picker page.
```

There seems to be something specific about how billboard's puzzleme embed uses a puzzleme endpoint (`cdn2.amuselabs.com/puzzleme`) where the other amuselabs-based sites have their own endpoints (eg `cdn3.amuselabs.com/atlantic`, `cdn3.amuselabs.com/vox`). I'll be honest I didn't look too closely at it; I just asked claude code to try to figure it out. Claude came up with a workaround using a base64-encoded session blob. No idea how fragile it is, but it seems to unblock this case, at least temporarily.  Figured I'd send it upstream in case you wanted to use it.