### PR TITLE
Add date selection to Billboard downloader

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Test Atlantic by date
         if: '!cancelled()'
         run: xword-dl atl -d 12/15/23
-      - name: Test Billboard latest
+      - name: Test Billboard by date
         if: '!cancelled()'
-        run: xword-dl bill
+        run: xword-dl bill -d 2/10/26
       - name: Test Crossword Club latest
         if: '!cancelled()'
         run: xword-dl club

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported outlets:
 |------|-------|:-------------:|:------------:|:-----------:|
 |*Atlantic*|`atl`|✔️|✔️||
 |*Crossword Club*|`club`|✔️|✔️|✔️|
-|*Billboard*|`bill`|✔️|||
+|*Billboard*|`bill`||✔️||
 |*The Daily Beast*|`db`|✔️|||
 |*Daily Pop*|`pop`|✔️|✔️||
 |*Der Standard*|`std`|✔️||✔️|

--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -100,7 +100,7 @@ class AmuseLabsDownloader(BaseDownloader):
                 "This outlet does not support finding the latest crossword."
             )
 
-        res = self.session.get(self.picker_url)
+        res = requests.get(self.picker_url)
 
         self.id = self._select_puzzle_at_index_from_date_picker(
             picker_src=res.text, index=0
@@ -126,17 +126,27 @@ class AmuseLabsDownloader(BaseDownloader):
 
         puzzles = param_obj.get("streakInfo", [])
 
-        if not puzzles:
-            raise XWordDLException("Unable to find puzzles data from picker page.")
+        if puzzles:
+            selected_id = puzzles[index].get("puzzleDetails", []).get("puzzleId")
 
-        selected_id = puzzles[index].get("puzzleDetails", []).get("puzzleId")
+            if not selected_id:
+                raise XWordDLException(
+                    "Unexpected puzzle metadata format. Please report this as a bug."
+                )
 
-        if not selected_id:
-            raise XWordDLException(
-                "Unexpected puzzle metadata format. Please report this as a bug."
-            )
+            return selected_id
 
-        return selected_id
+        rawsps = param_obj.get("rawsps", "")
+        if rawsps:
+            try:
+                sps = json.loads(base64.b64decode(rawsps + "==").decode("utf-8"))
+                puzzle_id = sps.get("id")
+                if puzzle_id:
+                    return puzzle_id
+            except (ValueError, KeyError):
+                pass
+
+        raise XWordDLException("Unable to find puzzles data from picker page.")
 
     def get_and_add_picker_token(self, picker_source=None):
         if self.picker_url is None:
@@ -144,7 +154,7 @@ class AmuseLabsDownloader(BaseDownloader):
                 "No picker URL was available. Please report this as a bug."
             )
         if not picker_source:
-            res = self.session.get(self.picker_url)
+            res = requests.get(self.picker_url)
             picker_source = res.text
 
         if "pickerParams.rawsps" in picker_source:
@@ -170,18 +180,6 @@ class AmuseLabsDownloader(BaseDownloader):
             token = picker_params.get("loadToken", None)
             if token:
                 self.url_from_id += "&loadToken=" + token
-
-        set_name = (
-            urllib.parse.parse_qs(urllib.parse.urlparse(self.picker_url).query).get(
-                "set", [None]
-            )[0]
-            if self.picker_url
-            else None
-        )
-        uid = self.session.cookies.get("uid")
-        if set_name and self.id and uid:
-            assert self.url_from_id is not None
-            self.url_from_id += "&fvlt=" + _compute_fvlt(set_name, self.id, uid)
 
     def find_puzzle_url_from_id(self, puzzle_id):
         if self.url_from_id is None:
@@ -341,25 +339,6 @@ class AmuseLabsDownloader(BaseDownloader):
         if not self.date and self.id:
             self.guess_date_from_id(self.id)
         return super().pick_filename(puzzle, **kwargs)
-
-
-def _compute_fvlt(set_name: str, puzzle_id: str, uid: str) -> str:
-    """Compute the fvlt (first-visit load token) required by the AmuseLabs puzzle viewer.
-
-    Reverse-engineered from picker-min.js. The token is an XOR of unsigned
-    32-bit char-sum hashes of the set name, puzzle ID, and session UID cookie,
-    formatted as a lowercase hex string.
-    """
-
-    def charsum(s: str) -> int:
-        t = 0
-        for c in s:
-            t = (t + ord(c)) & 0xFFFFFFFF
-        return t
-
-    return format(
-        (charsum(set_name) ^ charsum(puzzle_id) ^ charsum(uid)) & 0xFFFFFFFF, "x"
-    )
 
 
 # helper functions for rawc deobfuscation

--- a/src/xword_dl/downloader/billboarddownloader.py
+++ b/src/xword_dl/downloader/billboarddownloader.py
@@ -1,3 +1,10 @@
+import base64
+import datetime
+import json
+import re
+
+import requests
+
 from .amuselabsdownloader import AmuseLabsDownloader
 from ..util import XWordDLException
 
@@ -10,6 +17,11 @@ class BillboardDownloader(AmuseLabsDownloader):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self.picker_url = (
+            "https://cdn2.amuselabs.com/pmm/date-picker?set=billboard-crossword"
+        )
+        self.url_from_id = "https://cdn2.amuselabs.com/pmm/crossword?id={puzzle_id}&set=billboard-crossword"
+
     @classmethod
     def matches_url(cls, url_components):
         return (
@@ -18,9 +30,15 @@ class BillboardDownloader(AmuseLabsDownloader):
         )
 
     def find_latest(self) -> str:
-        return "https://www.billboard.com/p/billboard-crossword"
+        raise XWordDLException(
+            "Billboard ran from October 2, 2025 to February 10, 2026 and is no longer publishing. "
+            "Use --date to download a puzzle from the archive."
+        )
 
     def find_solver(self, url) -> str:
+        if "amuselabs.com" in url:
+            return url
+
         res = self.session.get(url)
 
         if not res.ok:
@@ -32,6 +50,94 @@ class BillboardDownloader(AmuseLabsDownloader):
             raise XWordDLException("Can't find latest Billboard puzzle.")
 
         return solver_url
+
+    def _get_archive(self):
+        if hasattr(self, "_archive_cache"):
+            return self._archive_cache
+
+        # Fetch the picker page to get a loadToken for the archive API
+        res = requests.get(
+            "https://cdn2.amuselabs.com/pmm/date-picker?set=billboard-crossword"
+        )
+        if not res.ok:
+            raise XWordDLException("Could not reach Billboard puzzle picker.")
+
+        m = re.search(r'id="params"[^>]*>([^<]+)<', res.text, re.DOTALL)
+        if not m:
+            raise XWordDLException("Could not parse Billboard picker page.")
+        obj = json.loads(m.group(1).strip())
+        rawsps = obj.get("rawsps", "")
+        try:
+            sps = json.loads(base64.b64decode(rawsps + "==").decode("utf-8"))
+            load_token = sps.get("loadToken", "")
+        except Exception:
+            raise XWordDLException(
+                "Could not extract auth token from Billboard picker."
+            )
+
+        if not load_token:
+            raise XWordDLException(
+                "Could not retrieve authentication token for Billboard archive."
+            )
+
+        api_res = self.session.get(
+            "https://cdn2.amuselabs.com/pmm/api/v1/puzzles",
+            params={
+                "set": "billboard-crossword",
+                "limit": 200,
+                "offset": 0,
+                "loadToken": load_token,
+            },
+        )
+        if not api_res.ok:
+            raise XWordDLException("Could not fetch Billboard puzzle archive.")
+
+        self._archive_cache = (
+            api_res.json()
+            .get("seriesToPuzzleMetadata", {})
+            .get("billboard-crossword", [])
+        )
+        return self._archive_cache
+
+    def find_by_date(self, dt):
+        self.date = dt
+        target_date_str = dt.strftime("%Y%m%d")
+
+        puzzles = self._get_archive()
+
+        # Match by ID suffix (most IDs are TitleSlug_YYYYMMDD)
+        puzzle_id = next(
+            (
+                p.get("puzzleId")
+                for p in puzzles
+                if p.get("puzzleId", "").endswith("_" + target_date_str)
+            ),
+            None,
+        )
+
+        # Fall back to matching by publication timestamp
+        if not puzzle_id:
+            target_date = dt.date() if hasattr(dt, "date") else dt
+            puzzle_id = next(
+                (
+                    p.get("puzzleId")
+                    for p in puzzles
+                    if datetime.datetime.utcfromtimestamp(
+                        p.get("publicationTime", 0) / 1000
+                    ).date()
+                    == target_date
+                ),
+                None,
+            )
+
+        if not puzzle_id:
+            raise XWordDLException(
+                f"No Billboard puzzle found for {dt.strftime('%Y-%m-%d')}."
+            )
+
+        self.id = puzzle_id
+        # Return crossword URL without loadToken — it works unauthenticated
+        return f"https://cdn2.amuselabs.com/pmm/crossword?id={puzzle_id}&set=billboard-crossword"
 
     def parse_xword(self, xw_data):
         # Billboard puzzles are typically untitled, and some have the title set to '-'


### PR DESCRIPTION
Billboard stopped publishing new puzzles after February 10, 2026. The full archive (October 2, 2025 – February 10, 2026, 95 puzzles) is still available via the AmuseLabs API.

Changes:
- BillboardDownloader: implement find_by_date() to look up puzzles from the AmuseLabs archive API using a load token extracted from the picker page; puzzle IDs contain an unpredictable title slug so they cannot be constructed from the date alone
- BillboardDownloader: find_latest() now raises an informative error directing users to --date with the full archive date range
- AmuseLabsDownloader: use bare requests.get for picker page fetches to avoid session/cookie interference; fall back to rawsps.id when streakInfo is empty; remove fvlt token computation that caused 'Load not verified' errors on some outlets
- README: mark Billboard as date-searchable rather than latest-only
- CI: replace 'test latest' step with 'test by date' (Feb 10, 2026)

Fixes #340 