### PR TITLE
Add date selection to Billboard downloader

### DIFF
--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Test Atlantic by date
         if: '!cancelled()'
         run: xword-dl atl -d 12/15/23
-      - name: Test Billboard latest
+      - name: Test Billboard by date
         if: '!cancelled()'
-        run: xword-dl bill
+        run: xword-dl bill -d 2/10/26
       - name: Test Crossword Club latest
         if: '!cancelled()'
         run: xword-dl club

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported outlets:
 |------|-------|:-------------:|:------------:|:-----------:|
 |*Atlantic*|`atl`|✔️|✔️||
 |*Crossword Club*|`club`|✔️|✔️|✔️|
-|*Billboard*|`bill`|✔️|||
+|*Billboard*|`bill`||✔️||
 |*The Daily Beast*|`db`|✔️|||
 |*Daily Pop*|`pop`|✔️|✔️||
 |*Der Standard*|`std`|✔️||✔️|

--- a/src/xword_dl/downloader/billboarddownloader.py
+++ b/src/xword_dl/downloader/billboarddownloader.py
@@ -1,3 +1,11 @@
+import base64
+import datetime
+import functools
+import json
+import re
+
+import requests
+
 from .amuselabsdownloader import AmuseLabsDownloader
 from ..util import XWordDLException
 
@@ -10,6 +18,11 @@ class BillboardDownloader(AmuseLabsDownloader):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self.picker_url = (
+            "https://cdn2.amuselabs.com/pmm/date-picker?set=billboard-crossword"
+        )
+        self.url_from_id = "https://cdn2.amuselabs.com/pmm/crossword?id={puzzle_id}&set=billboard-crossword"
+
     @classmethod
     def matches_url(cls, url_components):
         return (
@@ -18,9 +31,15 @@ class BillboardDownloader(AmuseLabsDownloader):
         )
 
     def find_latest(self) -> str:
-        return "https://www.billboard.com/p/billboard-crossword"
+        raise XWordDLException(
+            "Billboard ran from October 2, 2025 to February 10, 2026 and is no longer publishing. "
+            "Use --date to download a puzzle from the archive."
+        )
 
     def find_solver(self, url) -> str:
+        if "amuselabs.com" in url:
+            return url
+
         res = self.session.get(url)
 
         if not res.ok:
@@ -32,6 +51,91 @@ class BillboardDownloader(AmuseLabsDownloader):
             raise XWordDLException("Can't find latest Billboard puzzle.")
 
         return solver_url
+
+    @functools.cached_property
+    def _archive(self):
+        # Fetch the picker page to get a loadToken for the archive API
+        res = requests.get(
+            "https://cdn2.amuselabs.com/pmm/date-picker?set=billboard-crossword"
+        )
+        if not res.ok:
+            raise XWordDLException("Could not reach Billboard puzzle picker.")
+
+        m = re.search(r'id="params"[^>]*>([^<]+)<', res.text, re.DOTALL)
+        if not m:
+            raise XWordDLException("Could not parse Billboard picker page.")
+        obj = json.loads(m.group(1).strip())
+        rawsps = obj.get("rawsps", "")
+        try:
+            sps = json.loads(base64.b64decode(rawsps + "==").decode("utf-8"))
+            load_token = sps.get("loadToken", "")
+        except Exception:
+            raise XWordDLException(
+                "Could not extract auth token from Billboard picker."
+            )
+
+        if not load_token:
+            raise XWordDLException(
+                "Could not retrieve authentication token for Billboard archive."
+            )
+
+        api_res = self.session.get(
+            "https://cdn2.amuselabs.com/pmm/api/v1/puzzles",
+            params={
+                "set": "billboard-crossword",
+                "limit": 200,
+                "offset": 0,
+                "loadToken": load_token,
+            },
+        )
+        if not api_res.ok:
+            raise XWordDLException("Could not fetch Billboard puzzle archive.")
+
+        return (
+            api_res.json()
+            .get("seriesToPuzzleMetadata", {})
+            .get("billboard-crossword", [])
+        )
+
+    def find_by_date(self, dt):
+        self.date = dt
+        target_date_str = dt.strftime("%Y%m%d")
+
+        puzzles = self._archive
+
+        # Match by ID suffix (most IDs are TitleSlug_YYYYMMDD)
+        puzzle_id = next(
+            (
+                p.get("puzzleId")
+                for p in puzzles
+                if p.get("puzzleId", "").endswith("_" + target_date_str)
+            ),
+            None,
+        )
+
+        # Fall back to matching by publication timestamp
+        if not puzzle_id:
+            target_date = dt.date() if hasattr(dt, "date") else dt
+            puzzle_id = next(
+                (
+                    p.get("puzzleId")
+                    for p in puzzles
+                    if datetime.datetime.utcfromtimestamp(
+                        p.get("publicationTime", 0) / 1000
+                    ).date()
+                    == target_date
+                ),
+                None,
+            )
+
+        if not puzzle_id:
+            raise XWordDLException(
+                f"No Billboard puzzle found for {dt.strftime('%Y-%m-%d')}."
+            )
+
+        self.id = puzzle_id
+        # Return crossword URL without loadToken — it works unauthenticated
+        return f"https://cdn2.amuselabs.com/pmm/crossword?id={puzzle_id}&set=billboard-crossword"
 
     def parse_xword(self, xw_data):
         # Billboard puzzles are typically untitled, and some have the title set to '-'


### PR DESCRIPTION
Billboard stopped publishing new puzzles after February 10, 2026. The full archive (October 2, 2025 – February 10, 2026, 95 puzzles) is still available via the AmuseLabs API.

Changes:
- BillboardDownloader: implement find_by_date() to look up puzzles from the AmuseLabs archive API using a load token extracted from the picker page; puzzle IDs contain an unpredictable title slug so they cannot be constructed from the date alone. the archive index is cached (functools.cached_property) so that it is not refetched for multiple find_by_date calls (when xword-dl is used as a library for bulk download). 
- BillboardDownloader: find_latest() now raises an informative error directing users to --date with the full archive date range
- AmuseLabsDownloader: use bare requests.get for picker page fetches to avoid session/cookie interference; fall back to rawsps.id when streakInfo is empty; remove fvlt token computation that caused 'Load not verified' errors on some outlets
- README: mark Billboard as date-searchable rather than latest-only
- CI: replace 'test latest' step with 'test by date' (Feb 10, 2026)

Fixes #340 