### PR TITLE
Update usage of puz.py

### DIFF
--- a/src/xword_dl/downloader/amuselabsdownloader.py
+++ b/src/xword_dl/downloader/amuselabsdownloader.py
@@ -266,48 +266,41 @@ class AmuseLabsDownloader(BaseDownloader):
 
         markup_data = xw_data.get("cellInfos", "")
 
-        circled = [
+        circled_coords = {
             (square["x"], square["y"]) for square in markup_data if square["isCircled"]
-        ]
+        }
 
         solution = ""
         fill = ""
-        markup = b""
-        rebus_board = []
-        rebus_index = 0
-        rebus_table = ""
+        circled = []
 
         box = xw_data["box"]
+        i = 0
         for row_num in range(xw_data.get("h")):
             for col_num, column in enumerate(box):
                 cell = column[row_num]
                 if cell == "\x00":
                     solution += "."
                     fill += "."
-                    markup += b"\x00"
-                    rebus_board.append(0)
                 elif len(cell) == 1:
                     solution += cell
                     fill += "-"
-                    markup += b"\x80" if (col_num, row_num) in circled else b"\x00"
-                    rebus_board.append(0)
+                    if (col_num, row_num) in circled_coords:
+                        circled.append(i)
                 elif not cell:
                     solution += "X"
                     fill += "-"
-                    markup += b"\x00"
-                    rebus_board.append(0)
                 else:
                     solution += cell[0]
                     fill += "-"
-                    rebus_board.append(rebus_index + 1)
-                    rebus_table += "{:2d}:{};".format(rebus_index, unidecode(cell))
-                    rebus_index += 1
+                    puzzle.rebus().add_rebus_squares(i, unidecode(cell))
+                i += 1
 
         puzzle.solution = solution
         puzzle.fill = fill
 
         if all(c in [".", "X"] for c in puzzle.solution):
-            puzzle.solution_state = 0x0002
+            puzzle.solution_state = puz.SolutionState.NotProvided
             puzzle.title += " - no solution provided"
 
         placed_words = xw_data["placedWords"]
@@ -321,19 +314,8 @@ class AmuseLabsDownloader(BaseDownloader):
 
         puzzle.clues.extend(clues)
 
-        has_markup = b"\x80" in markup
-        has_rebus = any(rebus_board)
-
-        if has_markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
-
-        if has_rebus:
-            puzzle.extensions[b"GRBS"] = bytes(rebus_board)
-            puzzle.extensions[b"RTBL"] = rebus_table.encode(puz.ENCODING)
-            puzzle._extensions_order.extend([b"GRBS", b"RTBL"])
-            puzzle.rebus()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         return puzzle
 

--- a/src/xword_dl/downloader/compilerdownloader.py
+++ b/src/xword_dl/downloader/compilerdownloader.py
@@ -40,18 +40,20 @@ class CrosswordCompilerDownloader(BaseDownloader):
 
         solution = ""
         fill = ""
-        markup = b""
+        circled = []
 
         cells = {(int(cell["@x"]), int(cell["@y"])): cell for cell in xw_grid["cell"]}
 
-        for y in range(1, puzzle.height + 1):
-            for x in range(1, puzzle.width + 1):
-                cell = cells[(x, y)]
-                solution += cell.get("@solution", ".")
-                fill += "." if cell.get("@type") == "block" else "-"
-                markup += (
-                    b"\x80" if (cell.get("@background-shape") == "circle") else b"\x00"
-                )
+        for i, (y, x) in enumerate(
+            (y, x)
+            for y in range(1, puzzle.height + 1)
+            for x in range(1, puzzle.width + 1)
+        ):
+            cell = cells[(x, y)]
+            solution += cell.get("@solution", ".")
+            fill += "." if cell.get("@type") == "block" else "-"
+            if cell.get("@background-shape") == "circle":
+                circled.append(i)
 
         puzzle.solution = solution
         puzzle.fill = fill
@@ -68,12 +70,8 @@ class CrosswordCompilerDownloader(BaseDownloader):
 
         puzzle.clues = clues
 
-        has_markup = b"\x80" in markup
-
-        if has_markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         return puzzle
 

--- a/src/xword_dl/downloader/newyorktimesdownloader.py
+++ b/src/xword_dl/downloader/newyorktimesdownloader.py
@@ -146,20 +146,15 @@ class NewYorkTimesDownloader(BaseDownloader):
 
         solution = ""
         fill = ""
-        markup = b""
-        rebus_board = []
-        rebus_index = 0
-        rebus_table = ""
+        circled = []
 
         for idx, square in enumerate(xw_data["body"][0]["cells"]):
             if not square:
                 solution += "."
                 fill += "."
-                rebus_board.append(0)
-            elif square and len(square.get("answer", "")) == 1:
+            elif len(square.get("answer", "")) == 1:
                 solution += square["answer"]
                 fill += "-"
-                rebus_board.append(0)
             else:
                 try:
                     suitable_answer = unidecode(
@@ -172,25 +167,16 @@ class NewYorkTimesDownloader(BaseDownloader):
 
                 solution += suitable_answer[0]
                 fill += "-"
-                rebus_board.append(rebus_index + 1)
-                rebus_table += "{:2d}:{};".format(rebus_index, suitable_answer)
-                rebus_index += 1
+                puzzle.rebus().add_rebus_squares(idx, suitable_answer)
 
-            markup += b"\x00" if square.get("type", 1) == 1 else b"\x80"
+            if square and square.get("type", 1) != 1:
+                circled.append(idx)
 
         puzzle.solution = solution
         puzzle.fill = fill
 
-        if b"\x80" in markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
-
-        if any(rebus_board):
-            puzzle.extensions[b"GRBS"] = bytes(rebus_board)
-            puzzle.extensions[b"RTBL"] = rebus_table.encode(puz.ENCODING)
-            puzzle._extensions_order.extend([b"GRBS", b"RTBL"])
-            puzzle.rebus()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         clue_list = xw_data["body"][0]["clues"]
         clue_list.sort(key=lambda c: (int(c["label"]), c["direction"]))
@@ -234,7 +220,7 @@ class NewYorkTimesVarietyDownloader(NewYorkTimesDownloader):
                 "Encountered error while parsing data. Maybe the selected puzzle is not a crossword?"
             )
         if xw_data.get("subcategory") == 3:
-            puzzle.puzzletype = 0x0401  # PuzzleType.Diagramless
+            puzzle.puzzletype = puz.PuzzleType.Diagramless
         return puzzle
 
 

--- a/src/xword_dl/downloader/princetoniandownloader.py
+++ b/src/xword_dl/downloader/princetoniandownloader.py
@@ -104,14 +104,8 @@ class PrincetonianBaseDownloader(BaseDownloader):
         puzzle.fill = "".join("-" if c != "." else "." for c in puzzle.solution)
 
         if circled:
-            markup = bytes(
-                0x80 if (col, row) in circled else 0x00
-                for row in range(height)
-                for col in range(width)
-            )
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
+            indices = [row * width + col for col, row in circled]
+            puzzle.markup().set_markup_squares(indices, puz.GridMarkup.Circled)
 
         sorted_clues = sorted(clues, key=lambda c: (c["y"], c["x"], not c["is_across"]))
         puzzle.clues = [c["clue"] for c in sorted_clues]

--- a/src/xword_dl/downloader/puzzmodownloader.py
+++ b/src/xword_dl/downloader/puzzmodownloader.py
@@ -153,10 +153,8 @@ class PuzzmoDownloader(BaseDownloader):
         observed_width = 0
         fill = ""
         solution = ""
-        markup = b""
-        rebus_board = []
-        rebus_index = 0
-        rebus_table = ""
+        circled = []
+        design_idx = 0
         clue_list = []
         rebus_entries = {}
 
@@ -230,34 +228,21 @@ class PuzzmoDownloader(BaseDownloader):
                     continue
                 else:
                     for c in line:
-                        markup += b"\x00" if c in "#." else b"\x80"
-
-        for c in solution:
-            if c in rebus_entries:
-                rebus_board.append(rebus_index + 1)
-                rebus_table += "{:2d}:{};".format(rebus_index, rebus_entries[c])
-                rebus_index += 1
-            else:
-                rebus_board.append(0)
+                        if c not in "#.":
+                            circled.append(design_idx)
+                        design_idx += 1
 
         puzzle.height = observed_height
         puzzle.width = observed_width
         puzzle.solution = solution
         puzzle.fill = fill
 
-        has_markup = b"\x80" in markup
-        has_rebus = any(rebus_board)
+        for i, c in enumerate(solution):
+            if c in rebus_entries:
+                puzzle.rebus().add_rebus_squares(i, rebus_entries[c])
 
-        if has_markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
-
-        if has_rebus:
-            puzzle.extensions[b"GRBS"] = bytes(rebus_board)
-            puzzle.extensions[b"RTBL"] = rebus_table.encode(puz.ENCODING)
-            puzzle._extensions_order.extend([b"GRBS", b"RTBL"])
-            puzzle.rebus()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         clue_list.sort(key=lambda c: (c[1], c[0]))
 

--- a/src/xword_dl/downloader/puzzmodownloader.py
+++ b/src/xword_dl/downloader/puzzmodownloader.py
@@ -234,12 +234,17 @@ class PuzzmoDownloader(BaseDownloader):
 
         puzzle.height = observed_height
         puzzle.width = observed_width
-        puzzle.solution = solution
         puzzle.fill = fill
 
+        # Puzzmo uses non-latin-1 placeholders (e.g. ❶❷❸) in the grid for
+        # rebus cells; the .puz solution must be one latin-1 char per cell, so
+        # substitute the first letter of the rebus value per convention.
+        solution_chars = list(solution)
         for i, c in enumerate(solution):
             if c in rebus_entries:
                 puzzle.rebus().add_rebus_squares(i, rebus_entries[c])
+                solution_chars[i] = rebus_entries[c][0].upper()
+        puzzle.solution = "".join(solution_chars)
 
         if circled:
             puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)

--- a/src/xword_dl/downloader/wapodownloader.py
+++ b/src/xword_dl/downloader/wapodownloader.py
@@ -83,17 +83,17 @@ class WaPoDownloader(BaseDownloader):
 
         solution = ""
         fill = ""
-        markup = b""
+        circled = []
 
-        for cell in xw_data["cells"]:
+        for i, cell in enumerate(xw_data["cells"]):
             if ans := cell.get("answer"):
                 solution += ans
                 fill += "-"
-                markup += b"\x80" if cell.get("circle") else b"\x00"
+                if cell.get("circle"):
+                    circled.append(i)
             else:
                 solution += "."
                 fill += "."
-                markup += b"\x00"
 
         puzzle.solution = solution
         puzzle.fill = fill
@@ -105,11 +105,7 @@ class WaPoDownloader(BaseDownloader):
 
         puzzle.clues = [clue["clue"].strip() for clue in clues]
 
-        has_markup = b"\x80" in markup
-
-        if has_markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         return puzzle

--- a/src/xword_dl/downloader/wsjdownloader.py
+++ b/src/xword_dl/downloader/wsjdownloader.py
@@ -91,31 +91,26 @@ class WSJDownloader(BaseDownloader):
 
         solution = ""
         fill = ""
-        markup = b""
+        circled = []
+        i = 0
 
         for row in xw_data:
             for cell in row:
                 if cell.get("Blank"):
                     fill += "."
                     solution += "."
-                    markup += b"\x00"
                 else:
                     fill += "-"
                     solution += cell["Letter"] or "X"
-                    markup += (
-                        b"\x80"
-                        if (
-                            cell.get("style", "")
-                            and cell["style"]["shapebg"] == "circle"
-                        )
-                        else b"\x00"
-                    )
+                    if cell.get("style", "") and cell["style"]["shapebg"] == "circle":
+                        circled.append(i)
+                i += 1
 
         puzzle.fill = fill
         puzzle.solution = solution
 
         if all(c in [".", "X"] for c in puzzle.solution):
-            puzzle.solution_state = 0x0002
+            puzzle.solution_state = puz.SolutionState.NotProvided
 
         clue_list = (
             xword_metadata["clues"][0]["clues"] + xword_metadata["clues"][1]["clues"]
@@ -126,11 +121,7 @@ class WSJDownloader(BaseDownloader):
 
         puzzle.clues = clues
 
-        has_markup = b"\x80" in markup
-
-        if has_markup:
-            puzzle.extensions[b"GEXT"] = markup
-            puzzle._extensions_order.append(b"GEXT")
-            puzzle.markup()
+        if circled:
+            puzzle.markup().set_markup_squares(circled, puz.GridMarkup.Circled)
 
         return puzzle


### PR DESCRIPTION
Most recent versions of puz.py have a simpler interface for working with Markup and Rebus tables. This commit cleans up downloaders' use of those which should make it easier to find and fix bugs.

Also, fix #342 while I'm at it.