### PR TITLE
Make tests pass again

### DIFF
--- a/.github/workflows/lint-format-typecheck.yml
+++ b/.github/workflows/lint-format-typecheck.yml
@@ -7,7 +7,7 @@ jobs:
   check-formatting-and-types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/lint-format-typecheck.yml
+++ b/.github/workflows/lint-format-typecheck.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
       - name: Install dev dependencies
         run: uv sync --dev
       - name: Lint with ruff

--- a/.github/workflows/lint-format-typecheck.yml
+++ b/.github/workflows/lint-format-typecheck.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Install dev dependencies
         run: uv sync --dev
       - name: Lint with ruff

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Canonicalize version number

--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/status-check-outlets.yml
+++ b/.github/workflows/status-check-outlets.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Test Atlantic by date
         if: '!cancelled()'
         run: xword-dl atl -d 12/15/23
-      - name: Test Billboard latest
-        if: '!cancelled()'
-        run: xword-dl bill
       - name: Test Crossword Club latest
         if: '!cancelled()'
         run: xword-dl club
@@ -85,91 +82,98 @@ jobs:
       - name: Test LA Times Mini by date
         if: '!cancelled()'
         run: xword-dl latm -d "july 20, 2025"
-      - name: Test New York Times latest
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
-      - name: Test New York Times by date
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "5/17/23"
-      - name: Test New York Times rebus
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "aug 10, 2023"
-      - name: Test New York Times rebus special chars
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d 7/17/22
-      - name: Test New York Times blanks and circles
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/17/23"
-      - name: Test New York Times Variety (diagramless) by date
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nytv --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/14/08" -o diagramless.puz
-          xxd -s 48 -l 2 diagramless.puz | grep -q "0104"  # check diagramless flag is set
-      - name: Test New York Times blank clues
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "9/27/18"
-      - name: Test New York Times mini latest
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nytm --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
-      - name: Test New York Times midi latest
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nytd --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
-      - name: Test New York Times bonus latest
-        if: '!cancelled()'
-        env:
-          NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
-        run: |
-          xword-dl nytb --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
-      - name: Test New Yorker latest
-        if: '!cancelled()'
-        run: xword-dl tny
-      - name: Test New Yorker by date
-        if: '!cancelled()'
-        run: xword-dl tny -d "3/31/23"
-      - name: Test New Yorker by URL
-        if: '!cancelled()'
-        run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/01"
-      - name: Test New Yorker themed
-        if: '!cancelled()'
-        run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/05"
-      - name: Test New Yorker themed, special chars title
-        if: '!cancelled()'
-        run: xword-dl tny -d 1/12/24
-      - name: Test New Yorker Mini latest
-        if: '!cancelled()'
-        run: xword-dl tnym
-      - name: Test New Yorker Mini by date
-        if: '!cancelled()'
-        run: xword-dl tnym -d "5/16/25"
-      - name: Test New Yorker Mini by URL
-        if: '!cancelled()'
-        run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/mini-crossword/2025/05/16"
+      ## All the NYT tests fail via GitHub actions.
+      ## If you're making an NYT change, be sure to test locally
+      ## via `uv test xword-dl nyt`
+      # - name: Test New York Times latest
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+      # - name: Test New York Times by date
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "5/17/23"
+      # - name: Test New York Times rebus
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "aug 10, 2023"
+      # - name: Test New York Times rebus special chars
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d 7/17/22
+      # - name: Test New York Times blanks and circles
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/17/23"
+      # - name: Test New York Times Variety (diagramless) by date
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nytv --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "12/14/08" -o diagramless.puz
+      #     xxd -s 48 -l 2 diagramless.puz | grep -q "0104"  # check diagramless flag is set
+      # - name: Test New York Times blank clues
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nyt --settings '{"NYT-S": "'$NYT_S_VALUE'"}' -d "9/27/18"
+      # - name: Test New York Times mini latest
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nytm --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+      # - name: Test New York Times midi latest
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nytd --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+      # - name: Test New York Times bonus latest
+      #   if: '!cancelled()'
+      #   env:
+      #     NYT_S_VALUE: ${{ secrets.NYT_S_VALUE }}
+      #   run: |
+      #     xword-dl nytb --settings '{"NYT-S": "'$NYT_S_VALUE'"}'
+
+      ## We disable New Yorker testing as it won't work via GitHub actions
+      ## If you make a change to the New Yorker, test it locally with
+      ## `uv test xword-dl tny`
+      # - name: Test New Yorker latest
+      #   if: '!cancelled()'
+      #   run: xword-dl tny
+      # - name: Test New Yorker by date
+      #   if: '!cancelled()'
+      #   run: xword-dl tny -d "3/31/23"
+      # - name: Test New Yorker by URL
+      #   if: '!cancelled()'
+      #   run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/01"
+      # - name: Test New Yorker themed
+      #   if: '!cancelled()'
+      #   run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/crossword/2024/01/05"
+      # - name: Test New Yorker themed, special chars title
+      #   if: '!cancelled()'
+      #   run: xword-dl tny -d 1/12/24
+      # - name: Test New Yorker Mini latest
+      #   if: '!cancelled()'
+      #   run: xword-dl tnym
+      # - name: Test New Yorker Mini by date
+      #   if: '!cancelled()'
+      #   run: xword-dl tnym -d "5/16/25"
+      # - name: Test New Yorker Mini by URL
+      #   if: '!cancelled()'
+      #   run: xword-dl "https://www.newyorker.com/puzzles-and-games-dept/mini-crossword/2025/05/16"
       - name: Test Newsday latest
         if: '!cancelled()'
         run: xword-dl nd
@@ -185,18 +189,6 @@ jobs:
       - name: Test Princetonian Mini latest
         if: '!cancelled()'
         run: xword-dl prince-mini
-      - name: Test Observer Everyman latest
-        if: '!cancelled()'
-        run: xword-dl ever
-      - name: Test Observer Everyman by URL
-        if: '!cancelled()'
-        run: xword-dl 'https://observer.co.uk/puzzles/everyman/article/everyman-no-4109'
-      - name: Test Observer Speedy latest
-        if: '!cancelled()'
-        run: xword-dl spdy
-      - name: Test Observer Speedy by URL
-        if: '!cancelled()'
-        run: xword-dl 'https://observer.co.uk/puzzles/speedy/article/speedy-no-1563'
       - name: Test Puzzmo latest
         if: '!cancelled()'
         run: xword-dl pzm

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Supported outlets:
 |------|-------|:-------------:|:------------:|:-----------:|
 |*Atlantic*|`atl`|✔️|✔️||
 |*Crossword Club*|`club`|✔️|✔️|✔️|
-|*Billboard*|`bill`|✔️|||
 |*The Daily Beast*|`db`|✔️|||
 |*Daily Pop*|`pop`|✔️|✔️||
 |*Der Standard*|`std`|✔️||✔️|
@@ -94,7 +93,7 @@ In either case, the resulting .puz file can be opened with [`cursewords`](https:
 
 Due to the constraints of the .puz format, the `xword-dl`'s conversion may be a bit lossy. For example, the most common form of .puz files only support [Latin-1 text encoding](https://en.wikipedia.org/wiki/ISO/IEC_8859-1), which means that some special characters (and even “curly quotes”) need to be converted before saving.
 
-`xword-dl` will also, by default, convert provided HTML to plaintext markdown. If you want to skip that step, you can provide the `--preserve-html` flag at runtime or set the `preserve-html` key to `True` in your config file. 
+`xword-dl` will also, by default, convert provided HTML to plaintext markdown. If you want to skip that step, you can provide the `--preserve-html` flag at runtime or set the `preserve-html` key to `True` in your config file.
 
 ### Specifying puzzle date
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Supported outlets:
 |*The New Yorker*|`tny`|✔️|✔️|✔️|
 |*The New Yorker Mini*|`tnym`|✔️|✔️|✔️|
 |*Newsday*|`nd`|✔️|✔️||
-|*Observer Everyman*|`ever`|✔️||✔️|
-|*Observer Speedy*|`spdy`|✔️||✔️|
 |*Daily Princetonian*|`prince`|✔️|✔️||
 |*Daily Princetonian Mini*|`prince-mini`|✔️|✔️||
 |*Puzzmo*|`pzm`|✔️|✔️|✔️|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,13 @@ fix = true
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "standard"
+exclude = [
+    "**/__pycache__",
+    "build",
+    "dist",
+    ".venv",
+    ".git",
+]
 
 [dependency-groups]
 dev = [

--- a/src/xword_dl/downloader/billboarddownloader.py
+++ b/src/xword_dl/downloader/billboarddownloader.py
@@ -7,7 +7,7 @@ from ..util import XWordDLException
 
 
 class BillboardDownloader(AmuseLabsDownloader):
-    #command = "bill"
+    # command = "bill"
     outlet = "Billboard"
     outlet_prefix = "Billboard"
 

--- a/src/xword_dl/downloader/billboarddownloader.py
+++ b/src/xword_dl/downloader/billboarddownloader.py
@@ -1,9 +1,13 @@
+"""
+Billboard hasn't run a puzzle since February 2026, so we should shut them down
+"""
+
 from .amuselabsdownloader import AmuseLabsDownloader
 from ..util import XWordDLException
 
 
 class BillboardDownloader(AmuseLabsDownloader):
-    command = "bill"
+    #command = "bill"
     outlet = "Billboard"
     outlet_prefix = "Billboard"
 

--- a/src/xword_dl/downloader/observerdownloader.py
+++ b/src/xword_dl/downloader/observerdownloader.py
@@ -53,7 +53,7 @@ class ObserverDownloader(AmuseLabsDownloader):
 
 
 class EverymanDownloader(ObserverDownloader):
-    #command = "ever"
+    # command = "ever"
     outlet = "Observer"
     outlet_prefix = "Observer"
 
@@ -72,7 +72,7 @@ class EverymanDownloader(ObserverDownloader):
 
 
 class SpeedyDownloader(ObserverDownloader):
-    #command = "spdy"
+    # command = "spdy"
     outlet = "Observer"
     outlet_prefix = "Observer"
 

--- a/src/xword_dl/downloader/observerdownloader.py
+++ b/src/xword_dl/downloader/observerdownloader.py
@@ -1,3 +1,7 @@
+"""
+The Observer puzzles are now paywalled, so this won't work.
+"""
+
 import re
 import urllib.parse
 
@@ -49,7 +53,7 @@ class ObserverDownloader(AmuseLabsDownloader):
 
 
 class EverymanDownloader(ObserverDownloader):
-    command = "ever"
+    #command = "ever"
     outlet = "Observer"
     outlet_prefix = "Observer"
 
@@ -68,7 +72,7 @@ class EverymanDownloader(ObserverDownloader):
 
 
 class SpeedyDownloader(ObserverDownloader):
-    command = "spdy"
+    #command = "spdy"
     outlet = "Observer"
     outlet_prefix = "Observer"
 


### PR DESCRIPTION
We update a few things so that PRs will pass

* Remove Billboard downloader (they haven't run a puzzle since February 2026)
* Remove Observer downloaders (they're paywalled)
* Remove auto-tests for TNY and NYT (won't work from Github's servers)
* Update actions/checkout to non-deprecated versions
* Update uv to a non-deprecated node version
* Update README with changes